### PR TITLE
Having create-wallet generate WIF of root address

### DIFF
--- a/examples/applications/wallet/create-wallet/create-wallet.js
+++ b/examples/applications/wallet/create-wallet/create-wallet.js
@@ -57,6 +57,7 @@ for (let i = 0; i < 10; i++) {
   if (i === 0) {
     outObj.cashAddress = BITBOX.HDNode.toCashAddress(childNode)
     outObj.legacyAddress = BITBOX.HDNode.toLegacyAddress(childNode)
+    outObj.WIF = BITBOX.HDNode.toWIF(childNode)
   }
 }
 


### PR DESCRIPTION
This is a minor update to the `create-wallet` example. It simply appends a WIF to the .json file the app generates.