### PR TITLE
Added Schnorr to TransactionBuilder

### DIFF
--- a/lib/TransactionBuilder.js
+++ b/lib/TransactionBuilder.js
@@ -54,6 +54,10 @@ var TransactionBuilder = function () {
       ADVANCED_TRANSACTION_MARKER: 0x00,
       ADVANCED_TRANSACTION_FLAG: 0x01
     };
+    this.signatureAlgorithms = {
+      ECDSA: _bitcoincashjsLib2.default.ECSignature.ECDSA,
+      SCHNORR: _bitcoincashjsLib2.default.ECSignature.SCHNORR
+    };
     this.bip66 = _bip2.default;
     this.bip68 = _bcBip2.default;
     this.p2shInput = false;
@@ -105,10 +109,11 @@ var TransactionBuilder = function () {
     value: function sign(vin, keyPair, redeemScript) {
       var hashType = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : this.hashTypes.SIGHASH_ALL;
       var value = arguments[4];
+      var signatureAlgorithm = arguments[5];
 
       var witnessScript = void 0;
 
-      this.transaction.sign(vin, keyPair, redeemScript, hashType, value, witnessScript);
+      this.transaction.sign(vin, keyPair, redeemScript, hashType, value, witnessScript, signatureAlgorithm);
     }
   }, {
     key: "build",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1625,8 +1625,8 @@
       "integrity": "sha512-x0wMVSCZ56ZQnSQ+Xim7XfS0IYiOyOwo0pdMCmR+cDNB7zRhICFuH5i3lNdLSgUw1e7Pc3FmUlC9wruQNlYMnA=="
     },
     "bitcoincashjs-lib": {
-      "version": "github:Bitcoin-com/bitcoincashjs-lib#61ffec3878fd959d2a8a62f570a122ff801d78b6",
-      "from": "github:Bitcoin-com/bitcoincashjs-lib#3.4.4",
+      "version": "github:Bitcoin-com/bitcoincashjs-lib#3d360c780ec7df4a74aea93664c2b5ff8b08949a",
+      "from": "github:Bitcoin-com/bitcoincashjs-lib#v4.0.0",
       "requires": {
         "bech32": "^1.1.2",
         "bigi": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "bip39": "^2.5.0",
     "bip66": "^1.1.5",
     "bitcoincash-ops": "Bitcoin-com/bitcoincash-ops#2.0.0",
-    "bitcoincashjs-lib": "Bitcoin-com/bitcoincashjs-lib#3.4.4",
+    "bitcoincashjs-lib": "Bitcoin-com/bitcoincashjs-lib#v4.0.0",
     "bitcoinjs-message": "^2.0.0",
     "bs58": "^4.0.1",
     "buffer": "^5.1.0",

--- a/src/TransactionBuilder.js
+++ b/src/TransactionBuilder.js
@@ -26,6 +26,10 @@ class TransactionBuilder {
       ADVANCED_TRANSACTION_MARKER: 0x00,
       ADVANCED_TRANSACTION_FLAG: 0x01
     }
+    this.signatureAlgorithms = {
+      ECDSA: Bitcoin.ECSignature.ECDSA,
+      SCHNORR: Bitcoin.ECSignature.SCHNORR
+    }
     this.bip66 = bip66
     this.bip68 = bip68
     this.p2shInput = false
@@ -70,7 +74,8 @@ class TransactionBuilder {
     keyPair,
     redeemScript,
     hashType = this.hashTypes.SIGHASH_ALL,
-    value
+    value,
+    signatureAlgorithm
   ) {
     let witnessScript
 
@@ -80,7 +85,8 @@ class TransactionBuilder {
       redeemScript,
       hashType,
       value,
-      witnessScript
+      witnessScript,
+      signatureAlgorithm
     )
   }
 


### PR DESCRIPTION
Support for Schnorr signatures, [relevant PR](https://github.com/Bitcoin-com/bitcoincashjs-lib/pull/1).  

Additional parameter on `TransactionBuilder.sign()`: signatureAlgorithm, can be ECDSA (0) or SCHNORR (1).