### PR TITLE
Updating OP_RETURN test for livenet and to support all msg lengths

### DIFF
--- a/examples/low-level/OP_RETURN/op_return.js
+++ b/examples/low-level/OP_RETURN/op_return.js
@@ -4,12 +4,16 @@
 
 // Instantiate bitbox.
 const bitboxLib = "../../../lib/BITBOX"
-const BITBOX = require(bitboxLib).BITBOX
-const bitbox = new BITBOX({ restURL: "https://trest.bitcoin.com/v2/" })
+const BITBOXSDK = require(bitboxLib).BITBOX
+const bitbox = new BITBOXSDK()
 
 // Choose a transaction to parse for OP_Return
 
+// Long msg example (>20 char)
 const txid = `5b81b332c8fa5a2b2e77bb928bd18072af4485f02a7325d346f1f28cf3d4a6bb`
+
+// Short msg example (<20 char)
+//const txid = `d887132e3408f8d10e9b82bec447ca12e485cb6160af88d9b14f22ba865f6793`
 
 function parseOP_RETURN(txid) {
   console.log(`Parsing transaction ${txid} for messages in OP_RETURN...`)
@@ -20,50 +24,71 @@ function parseOP_RETURN(txid) {
     tx => {
       // You may wish to log this tx info to the console to inspect and plan your parsing function
       // console.log(tx)
-
+      
       // Begin parsing transaction
 
       // Initialize an array to store any OP_Return messages
-      const messages = []
+      let messages = []
 
       // Iterate over outputs looking for OP_Return outputs
+    
+      for (let i=0; i < tx.vout.length; i++) {        
+        
+        // If this is an OP_Return output        
+        if (typeof tx.vout[i].scriptPubKey.addresses === 'undefined') {
+          
+          let message = ''          
+          let fromAsm = ''
+          let decoded = ''
+          
+          //Pretty print your raw transaction data to the console
+          //console.log(JSON.stringify(tx, null, 2))
 
-      for (let i = 0; i < tx.vout.length; i++) {
-        // If this is an OP_Return output
-        if (typeof tx.vout[i].scriptPubKey.addresses === "undefined") {
-          let message = ""
+          try {
+            // Decode the OP_Return message
+            message = tx.vout[i].scriptPubKey.asm
 
-          // Decode the OP_Return message
-          message = tx.vout[i].scriptPubKey.asm
+            // If length is <= 20 characters, translate from hex            
+            if (message.length <= 20) {
+              message = tx.vout[i].scriptPubKey.hex
+              message = message.substring(4)
+              message = "OP_RETURN " + message              
+            }
 
-          const fromAsm = bitbox.Script.fromASM(message)
-          const decoded = bitbox.Script.decode(fromAsm)
-          message = decoded[1].toString("ascii")
+            fromAsm = bitbox.Script.fromASM(message)
+            decoded = bitbox.Script.decode(fromAsm)
+            console.log(`Decoded:`)
+            console.log(decoded)
+            message = decoded[1].toString('ascii')
 
-          // Add this decoded OP_Return message to an array, in case multiple outputs have OP_Return messages
-          messages.push(message)
+            // Add this decoded OP_Return message to an array, in case multiple outputs have OP_Return messages
+            messages.push(message)
+          }
+          catch(err) {
+            console.log(`Error in parsing OP_RETURN:`)
+            console.log(err)
+          }          
         }
       }
-
+      
       if (messages.length === 1) {
         console.log(`Message found!`)
         console.log(``)
         console.log(`Message: ${messages[0]}`)
-      } else {
+      }
+      else {
         console.log(`${messages.length} messages found!`)
         console.log(``)
-        for (let j = 0; j < messages.length; j++) {
-          console.log(
-            `Message ${j + 1} of ${messages.length + 1}: ${messages[j]}`
-          )
+        for (let j=0; j < messages.length; j++) {
+          console.log(`Message ${j+1} of ${messages.length+1}: ${messages[j]}`)
         }
       }
     },
     err => {
-      console.log("Error in bitbox.Transaction.details(${txid}):")
+      console.log('Error in bitbox.Transaction.details(${txid}):')
       console.log(err)
     }
-  )
+  ) 
 }
 
 parseOP_RETURN(txid)

--- a/examples/low-level/OP_RETURN/op_return.js
+++ b/examples/low-level/OP_RETURN/op_return.js
@@ -4,8 +4,8 @@
 
 // Instantiate bitbox.
 const bitboxLib = "../../../lib/BITBOX"
-const BITBOXSDK = require(bitboxLib).BITBOX
-const bitbox = new BITBOXSDK()
+const BITBOX = require(bitboxLib).BITBOX
+const bitbox = new BITBOX()
 
 // Choose a transaction to parse for OP_Return
 
@@ -57,8 +57,6 @@ function parseOP_RETURN(txid) {
 
             fromAsm = bitbox.Script.fromASM(message)
             decoded = bitbox.Script.decode(fromAsm)
-            console.log(`Decoded:`)
-            console.log(decoded)
             message = decoded[1].toString('ascii')
 
             // Add this decoded OP_Return message to an array, in case multiple outputs have OP_Return messages


### PR DESCRIPTION
- Adding shorter example OP_RETURN msg
- Code arbitrarily parses shorter OP_RETURN or longer OP_RETURN msgs (issue with parsing messages shorter than 20 characters using `fromASM`)
- Uses livenet as this method does not spend or risk funds