### PR TITLE
Expose bitcoincashjs-lib Script.number

### DIFF
--- a/lib/Script.ts
+++ b/lib/Script.ts
@@ -214,6 +214,11 @@ export interface scriptHash {
   }
 }
 
+export interface scriptNumber {
+  encode(number: number): Buffer
+  decode(buffer: Buffer, maxLength?: number, minimal?: boolean): number
+}
+
 export class Script {
   public opcodes: opcodes
   public nullData: nullData
@@ -221,6 +226,7 @@ export class Script {
   public pubKeyHash: pubKeyHash
   public multisig: multisig
   public scriptHash: scriptHash
+  public number: scriptNumber
 
   constructor() {
     this.opcodes = opcodes
@@ -252,6 +258,7 @@ export class Script {
     this.pubKey = Bitcoin.script.pubKey
     this.pubKeyHash = Bitcoin.script.pubKeyHash
     this.scriptHash = Bitcoin.script.scriptHash
+    this.number = Bitcoin.script.number
   }
 
   public encode(scriptChunks: Array<number | Buffer>): Buffer {

--- a/lib/Script.ts
+++ b/lib/Script.ts
@@ -396,4 +396,12 @@ export class Script {
   public checkP2SHOutput(output: Buffer): boolean {
     return this.scriptHash.output.check(output)
   }
+
+  public encodeNumber(number: number): Buffer {
+    return this.number.encode(number);
+  }
+
+  public decodeNumber(buffer: Buffer, maxLength?: number, minimal?: boolean): number {
+    return this.number.decode(buffer, maxLength, minimal);
+  }
 }

--- a/test/unit/Script.ts
+++ b/test/unit/Script.ts
@@ -430,16 +430,20 @@ describe("#Script", (): void => {
         })
     })
 
-    describe("#scriptNumber", (): void => {
+    describe("#number", (): void => {
         fixtures.scriptNumber.forEach((fixture: any): void => {
             it(`should encode number ${fixture.decoded} as bytes ${fixture.encoded}`, (): void => {
-                const encoded = bitbox.Script.number.encode(fixture.decoded)
-                assert.equal(encoded.toString("hex"), fixture.encoded)
+                const encoded1 = bitbox.Script.number.encode(fixture.decoded)
+                const encoded2 = bitbox.Script.encodeNumber(fixture.decoded)
+                assert.equal(encoded1.toString("hex"), fixture.encoded)
+                assert.equal(encoded2.toString("hex"), fixture.encoded)
             })
 
             it(`should decode bytes ${fixture.encoded} as number ${fixture.decoded}`, (): void => {
-                const decoded = bitbox.Script.number.decode(Buffer.from(fixture.encoded, 'hex'))
-                assert.equal(decoded, fixture.decoded)
+                const decoded1 = bitbox.Script.number.decode(Buffer.from(fixture.encoded, 'hex'))
+                const decoded2 = bitbox.Script.decodeNumber(Buffer.from(fixture.encoded, 'hex'))
+                assert.equal(decoded1, fixture.decoded)
+                assert.equal(decoded2, fixture.decoded)
             })
         })
     })

--- a/test/unit/Script.ts
+++ b/test/unit/Script.ts
@@ -429,4 +429,18 @@ describe("#Script", (): void => {
             })
         })
     })
+
+    describe("#scriptNumber", (): void => {
+        fixtures.scriptNumber.forEach((fixture: any): void => {
+            it(`should encode number ${fixture.decoded} as bytes ${fixture.encoded}`, (): void => {
+                const encoded = bitbox.Script.number.encode(fixture.decoded)
+                assert.equal(encoded.toString("hex"), fixture.encoded)
+            })
+
+            it(`should decode bytes ${fixture.encoded} as number ${fixture.decoded}`, (): void => {
+                const decoded = bitbox.Script.number.decode(Buffer.from(fixture.encoded, 'hex'))
+                assert.equal(decoded, fixture.decoded)
+            })
+        })
+    })
 })

--- a/test/unit/fixtures/Script.json
+++ b/test/unit/fixtures/Script.json
@@ -654,5 +654,19 @@
       "output": "OP_DUP OP_HASH160 aa4d7985c57e011a8b3dd8e0e5a73aaef41629c5 OP_EQUALVERIFY OP_CHECKSIG",
       "hex": "a9141b61ebed0c2a16c699a99c3d5ef4d08de7fb1cb887"
     }
+  ],
+  "scriptNumber": [
+    {
+      "decoded": 1,
+      "encoded": "01"
+    },
+    {
+      "decoded": -1,
+      "encoded": "81"
+    },
+    {
+      "decoded": 1000,
+      "encoded": "e803"
+    }
   ]
 }


### PR DESCRIPTION
- Expose the `number` member on bitbox.Script.
- Add wrapper methods for `number.encode` and `number.decode`.
- Add a typescript interface for this member.
- Add a few simple tests and fixtures for the exposed methods.