### PR TITLE
Expose the Socket constructor not an instance

### DIFF
--- a/lib/BITBOX.ts
+++ b/lib/BITBOX.ts
@@ -70,7 +70,7 @@ export class BITBOX {
     this.Transaction = new Transaction(this.restURL)
     this.TransactionBuilder = TransactionBuilder
     this.Util = new Util(this.restURL)
-    this.Socket = new Socket()
+    this.Socket = Socket
     this.Schnorr = new Schnorr()
     // this.Wallet = Wallet
   }

--- a/test/unit/BITBOX.ts
+++ b/test/unit/BITBOX.ts
@@ -18,6 +18,8 @@ import { TransactionBuilder } from "../../lib/TransactionBuilder"
 import { Util } from "../../lib/Util"
 import { Schnorr } from "../../lib/Schnorr"
 import { resturl } from "../../lib/BITBOX"
+import { Socket } from "../../lib/Socket"
+
 
 describe("#BITBOX", (): void => {
   describe("#BITBOXConstructor", (): void => {
@@ -109,6 +111,11 @@ describe("#BITBOX", (): void => {
     it("should have a Schnorr property", (): void => {
       const bitbox: BITBOX = new BITBOX({ restURL: resturl })
       assert.equal(bitbox.Schnorr instanceof Schnorr, true)
+    })
+
+    it("should have a Socket property", (): void => {
+      const bitbox: BITBOX = new BITBOX({ restURL: resturl })
+      assert.strictEqual(bitbox.Socket, Socket)
     })
   })
 })


### PR DESCRIPTION
The bug was introduced in https://github.com/Bitcoin-com/bitbox-sdk/commit/73074873aa7eb9704008bfaef64a2aa1908a8d6f.