### PR TITLE
BITBOX.ECPair gets BITBOX.Address passed as its Address instance

### DIFF
--- a/lib/BITBOX.ts
+++ b/lib/BITBOX.ts
@@ -59,7 +59,7 @@ export class BITBOX {
     this.Blockchain = new Blockchain(this.restURL)
     this.Control = new Control(this.restURL)
     this.Crypto = new Crypto()
-    this.ECPair = new ECPair()
+    this.ECPair = new ECPair(this.Address)
     this.Generating = new Generating(this.restURL)
     this.HDNode = new HDNode(this.Address)
     this.Mining = new Mining(this.restURL)


### PR DESCRIPTION
ECPair takes an Address instance (eg used in generating cash address). 
This was not being passed, rendering it impossible to generate testnet 
cashaddresses when using `bitbox.ECPair.toCashAddress()` when bitbox
is configured to use testnet config.