### PR TITLE
Add optional signatureAlgorithm parameter to ECPair.sign()

### DIFF
--- a/lib/interfaces/vendors.d.ts
+++ b/lib/interfaces/vendors.d.ts
@@ -17,7 +17,7 @@ declare module "bitcoincashjs-lib" {
 
   export interface ECPair {
     toWIF(): string
-    sign(buffer: Buffer): Boolean | ECSignature
+    sign(buffer: Buffer, signatureAlgorithm?: number): Boolean | ECSignature
     verify(buffer: Buffer, signature: ECSignature): boolean
     getPublicKeyBuffer(): Buffer
     getAddress(): string

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitbox-sdk",
-  "version": "8.2.0",
+  "version": "8.2.1",
   "description": "BITBOX SDK for Bitcoin Cash",
   "author": "Gabriel Cardona <gabriel@bitcoin.com>",
   "contributors": [


### PR DESCRIPTION
bitcoincashjs-lib `ECPair.sign()` has an optional signatureAlgorithm parameter. This was not exported in bitbox's `vendor.d.ts`.