### PR TITLE
Adding integration tests back in

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "test": "tsc && nyc mocha test/unit --timeout 60000 --exit",
-    "test:integration": "TEST=integration nyc --reporter=text mocha --require babel-core/register --timeout 30000 test/integration",
+    "test:integration": "TEST=integration nyc --reporter=text mocha --timeout 30000 test/integration",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "build": "tsc"
   },

--- a/test/integration/address.js
+++ b/test/integration/address.js
@@ -1,5 +1,5 @@
 /*
-  Integration tests for the bitbox.Address library. Only covers calls made to
+  Integration tests for the BITBOX.Address library. Only covers calls made to
   rest.bitcoin.com.
 
   TODO:
@@ -9,8 +9,342 @@
 
 const chai = require("chai")
 const assert = chai.assert
-const BITBOX = require("../../lib/BITBOX").BITBOX
-const bitbox = new BITBOX()
+const BITBOXSDK = require("../../lib/BITBOX").BITBOX
+const BITBOX = new BITBOXSDK()
 //const axios = require("axios")
 
 // Inspect utility used for debugging.
+const util = require("util")
+util.inspect.defaultOptions = {
+  showHidden: true,
+  colors: true,
+  depth: 3
+}
+
+describe(`#address`, () => {
+  describe(`#details`, () => {
+    it(`should GET address details for a single address`, async () => {
+      const addr = "bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf"
+
+      const result = await BITBOX.Address.details(addr)
+      //console.log(`result: ${util.inspect(result)}`)
+
+      assert.hasAllKeys(result, [
+        "balance",
+        "balanceSat",
+        "totalReceived",
+        "totalReceivedSat",
+        "totalSent",
+        "totalSentSat",
+        "unconfirmedBalance",
+        "unconfirmedBalanceSat",
+        "unconfirmedTxApperances",
+        "txApperances",
+        "transactions",
+        "legacyAddress",
+        "cashAddress",
+        "currentPage",
+        "pagesTotal"
+      ])
+      assert.isArray(result.transactions)
+    })
+
+    it(`should GET address details for an array of addresses`, async () => {
+      const addr = [
+        "bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf",
+        "bitcoincash:qpdh9s677ya8tnx7zdhfrn8qfyvy22wj4qa7nwqa5v"
+      ]
+
+      const result = await BITBOX.Address.details(addr)
+      //console.log(`result: ${util.inspect(result)}`)
+
+      assert.isArray(result)
+      assert.hasAllKeys(result[0], [
+        "balance",
+        "balanceSat",
+        "totalReceived",
+        "totalReceivedSat",
+        "totalSent",
+        "totalSentSat",
+        "unconfirmedBalance",
+        "unconfirmedBalanceSat",
+        "unconfirmedTxApperances",
+        "txApperances",
+        "transactions",
+        "legacyAddress",
+        "cashAddress",
+        "currentPage",
+        "pagesTotal"
+      ])
+      assert.isArray(result[0].transactions)
+    })
+
+    it(`should throw an error for improper input`, async () => {
+      try {
+        const addr = 12345
+
+        await BITBOX.Address.details(addr)
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        //console.log(`err: `, err)
+        assert.include(
+          err.message,
+          `Input address must be a string or array of strings`
+        )
+      }
+    })
+
+    it(`should throw error on array size rate limit`, async () => {
+      try {
+        const addr = []
+        for (let i = 0; i < 25; i++)
+          addr.push("bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf")
+
+        const result = await BITBOX.Address.details(addr)
+
+        console.log(`result: ${util.inspect(result)}`)
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        assert.hasAnyKeys(err, ["error"])
+        assert.include(err.error, "Array too large")
+      }
+    })
+  })
+
+  describe(`#utxo`, () => {
+    it(`should GET utxos for a single address`, async () => {
+      const addr = "bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf"
+
+      const result = await BITBOX.Address.utxo(addr)
+      //console.log(`result: ${JSON.stringify(result, null, 2)}`)
+
+      assert.hasAllKeys(result, [
+        "utxos",
+        "legacyAddress",
+        "cashAddress",
+        "scriptPubKey"
+      ])
+      assert.isArray(result.utxos)
+      assert.hasAnyKeys(result.utxos[0], [
+        "txid",
+        "vout",
+        "amount",
+        "satoshis",
+        "height",
+        "confirmations"
+      ])
+    })
+
+    it(`should GET utxo details for an array of addresses`, async () => {
+      const addr = [
+        "bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf",
+        "bitcoincash:qpdh9s677ya8tnx7zdhfrn8qfyvy22wj4qa7nwqa5v"
+      ]
+
+      const result = await BITBOX.Address.utxo(addr)
+      //console.log(`result: ${JSON.stringify(result, null, 2)}`)
+
+      assert.isArray(result)
+      assert.hasAllKeys(result[0], [
+        "utxos",
+        "legacyAddress",
+        "cashAddress",
+        "scriptPubKey"
+      ])
+      assert.isArray(result[0].utxos)
+      assert.hasAnyKeys(result[0].utxos[0], [
+        "txid",
+        "vout",
+        "amount",
+        "satoshis",
+        "height",
+        "confirmations"
+      ])
+    })
+
+    it(`should throw an error for improper input`, async () => {
+      try {
+        const addr = 12345
+
+        await BITBOX.Address.utxo(addr)
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        //console.log(`err: `, err)
+        assert.include(
+          err.message,
+          `Input address must be a string or array of strings`
+        )
+      }
+    })
+
+    it(`should throw error on array size rate limit`, async () => {
+      try {
+        const addr = []
+        for (let i = 0; i < 25; i++)
+          addr.push("bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf")
+
+        const result = await BITBOX.Address.utxo(addr)
+
+        console.log(`result: ${util.inspect(result)}`)
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        assert.hasAnyKeys(err, ["error"])
+        assert.include(err.error, "Array too large")
+      }
+    })
+  })
+
+  describe(`#unconfirmed`, () => {
+    it(`should GET unconfirmed details on a single address`, async () => {
+      const addr = "bitcoincash:qz7teqlcltdhqjn2an8nspu7g2x6g3d3rcq8nk4nzs"
+
+      const result = await BITBOX.Address.unconfirmed(addr)
+      //console.log(`result: ${JSON.stringify(result, null, 2)}`)
+
+      assert.hasAllKeys(result, ["utxos", "legacyAddress", "cashAddress"])
+      assert.isArray(result.utxos)
+    })
+
+    it(`should GET unconfirmed details on multiple addresses`, async () => {
+      const addr = [
+        "bitcoincash:qz7teqlcltdhqjn2an8nspu7g2x6g3d3rcq8nk4nzs",
+        "bitcoincash:qqcp8fw06dmjd2gnfanpwytj7q93w408nv7usdqgsk"
+      ]
+
+      const result = await BITBOX.Address.unconfirmed(addr)
+      //console.log(`result: ${JSON.stringify(result, null, 2)}`)
+
+      assert.isArray(result)
+      assert.hasAllKeys(result[0], ["utxos", "legacyAddress", "cashAddress"])
+      assert.isArray(result[0].utxos)
+    })
+
+    it(`should throw an error for improper input`, async () => {
+      try {
+        const addr = 12345
+
+        await BITBOX.Address.unconfirmed(addr)
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        //console.log(`err: `, err)
+        assert.include(
+          err.message,
+          `Input address must be a string or array of strings`
+        )
+      }
+    })
+
+    it(`should throw error on array size rate limit`, async () => {
+      try {
+        const addr = []
+        for (let i = 0; i < 25; i++)
+          addr.push("bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf")
+
+        const result = await BITBOX.Address.unconfirmed(addr)
+
+        console.log(`result: ${util.inspect(result)}`)
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        assert.hasAnyKeys(err, ["error"])
+        assert.include(err.error, "Array too large")
+      }
+    })
+  })
+
+  describe(`#transactions`, () => {
+    it(`should GET transactions for a single address`, async () => {
+      const addr = "bitcoincash:qz7teqlcltdhqjn2an8nspu7g2x6g3d3rcq8nk4nzs"
+
+      const result = await BITBOX.Address.transactions(addr)
+      //console.log(`result: ${JSON.stringify(result, null, 2)}`)
+
+      assert.hasAllKeys(result, [
+        "txs",
+        "pagesTotal",
+        "cashAddress",
+        "currentPage",
+        "legacyAddress"
+      ])
+      assert.isArray(result.txs)
+      assert.hasAnyKeys(result.txs[0], [
+        "txid",
+        "version",
+        "locktime",
+        "vin",
+        "vout",
+        "confirmations",
+        "time",
+        "blocktime",
+        "valueOut",
+        "size",
+        "valueIn",
+        "fees"
+      ])
+    })
+
+    it(`should get transactions on multiple addresses`, async () => {
+      const addr = [
+        "bitcoincash:qz7teqlcltdhqjn2an8nspu7g2x6g3d3rcq8nk4nzs",
+        "bitcoincash:qqcp8fw06dmjd2gnfanpwytj7q93w408nv7usdqgsk"
+      ]
+
+      const result = await BITBOX.Address.transactions(addr)
+      //console.log(`result: ${JSON.stringify(result, null, 2)}`)
+
+      assert.isArray(result)
+      assert.hasAllKeys(result[0], [
+        "txs",
+        "pagesTotal",
+        "cashAddress",
+        "currentPage",
+        "legacyAddress"
+      ])
+      assert.isArray(result[0].txs)
+      assert.hasAnyKeys(result[0].txs[0], [
+        "txid",
+        "version",
+        "locktime",
+        "vin",
+        "vout",
+        "confirmations",
+        "time",
+        "blocktime",
+        "valueOut",
+        "size",
+        "valueIn",
+        "fees"
+      ])
+    })
+
+    it(`should throw an error for improper input`, async () => {
+      try {
+        const addr = 12345
+
+        await BITBOX.Address.transactions(addr)
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        //console.log(`err: `, err)
+        assert.include(
+          err.message,
+          `Input address must be a string or array of strings`
+        )
+      }
+    })
+
+    it(`should throw error on array size rate limit`, async () => {
+      try {
+        const addr = []
+        for (let i = 0; i < 25; i++)
+          addr.push("bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf")
+
+        const result = await BITBOX.Address.transactions(addr)
+
+        console.log(`result: ${util.inspect(result)}`)
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        assert.hasAnyKeys(err, ["error"])
+        assert.include(err.error, "Array too large")
+      }
+    })
+  })
+})

--- a/test/integration/address.js
+++ b/test/integration/address.js
@@ -1,5 +1,5 @@
 /*
-  Integration tests for the BITBOX.Address library. Only covers calls made to
+  Integration tests for the bitbox.Address library. Only covers calls made to
   rest.bitcoin.com.
 
   TODO:
@@ -9,8 +9,9 @@
 
 const chai = require("chai")
 const assert = chai.assert
-const BITBOXSDK = require("../../lib/BITBOX").BITBOX
-const BITBOX = new BITBOXSDK()
+
+const BITBOX = require("../../lib/BITBOX").BITBOX
+const bitbox = new BITBOX()
 //const axios = require("axios")
 
 // Inspect utility used for debugging.
@@ -26,7 +27,7 @@ describe(`#address`, () => {
     it(`should GET address details for a single address`, async () => {
       const addr = "bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf"
 
-      const result = await BITBOX.Address.details(addr)
+      const result = await bitbox.Address.details(addr)
       //console.log(`result: ${util.inspect(result)}`)
 
       assert.hasAllKeys(result, [
@@ -56,7 +57,7 @@ describe(`#address`, () => {
         "bitcoincash:qpdh9s677ya8tnx7zdhfrn8qfyvy22wj4qa7nwqa5v"
       ]
 
-      const result = await BITBOX.Address.details(addr)
+      const result = await bitbox.Address.details(addr)
       //console.log(`result: ${util.inspect(result)}`)
 
       assert.isArray(result)
@@ -85,7 +86,7 @@ describe(`#address`, () => {
       try {
         const addr = 12345
 
-        await BITBOX.Address.details(addr)
+        await bitbox.Address.details(addr)
         assert.equal(true, false, "Unexpected result!")
       } catch (err) {
         //console.log(`err: `, err)
@@ -102,7 +103,7 @@ describe(`#address`, () => {
         for (let i = 0; i < 25; i++)
           addr.push("bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf")
 
-        const result = await BITBOX.Address.details(addr)
+        const result = await bitbox.Address.details(addr)
 
         console.log(`result: ${util.inspect(result)}`)
         assert.equal(true, false, "Unexpected result!")
@@ -117,7 +118,7 @@ describe(`#address`, () => {
     it(`should GET utxos for a single address`, async () => {
       const addr = "bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf"
 
-      const result = await BITBOX.Address.utxo(addr)
+      const result = await bitbox.Address.utxo(addr)
       //console.log(`result: ${JSON.stringify(result, null, 2)}`)
 
       assert.hasAllKeys(result, [
@@ -144,7 +145,7 @@ describe(`#address`, () => {
         "bitcoincash:qpdh9s677ya8tnx7zdhfrn8qfyvy22wj4qa7nwqa5v"
       ]
 
-      const result = await BITBOX.Address.utxo(addr)
+      const result = await bitbox.Address.utxo(addr)
       //console.log(`result: ${JSON.stringify(result, null, 2)}`)
 
       assert.isArray(result)
@@ -170,7 +171,7 @@ describe(`#address`, () => {
       try {
         const addr = 12345
 
-        await BITBOX.Address.utxo(addr)
+        await bitbox.Address.utxo(addr)
         assert.equal(true, false, "Unexpected result!")
       } catch (err) {
         //console.log(`err: `, err)
@@ -187,7 +188,7 @@ describe(`#address`, () => {
         for (let i = 0; i < 25; i++)
           addr.push("bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf")
 
-        const result = await BITBOX.Address.utxo(addr)
+        const result = await bitbox.Address.utxo(addr)
 
         console.log(`result: ${util.inspect(result)}`)
         assert.equal(true, false, "Unexpected result!")
@@ -202,7 +203,7 @@ describe(`#address`, () => {
     it(`should GET unconfirmed details on a single address`, async () => {
       const addr = "bitcoincash:qz7teqlcltdhqjn2an8nspu7g2x6g3d3rcq8nk4nzs"
 
-      const result = await BITBOX.Address.unconfirmed(addr)
+      const result = await bitbox.Address.unconfirmed(addr)
       //console.log(`result: ${JSON.stringify(result, null, 2)}`)
 
       assert.hasAllKeys(result, [
@@ -221,7 +222,7 @@ describe(`#address`, () => {
         "bitcoincash:qqcp8fw06dmjd2gnfanpwytj7q93w408nv7usdqgsk"
       ]
 
-      const result = await BITBOX.Address.unconfirmed(addr)
+      const result = await bitbox.Address.unconfirmed(addr)
       //console.log(`result: ${JSON.stringify(result, null, 2)}`)
 
       assert.isArray(result)
@@ -239,7 +240,7 @@ describe(`#address`, () => {
       try {
         const addr = 12345
 
-        await BITBOX.Address.unconfirmed(addr)
+        await bitbox.Address.unconfirmed(addr)
         assert.equal(true, false, "Unexpected result!")
       } catch (err) {
         //console.log(`err: `, err)
@@ -256,7 +257,7 @@ describe(`#address`, () => {
         for (let i = 0; i < 25; i++)
           addr.push("bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf")
 
-        const result = await BITBOX.Address.unconfirmed(addr)
+        const result = await bitbox.Address.unconfirmed(addr)
 
         console.log(`result: ${util.inspect(result)}`)
         assert.equal(true, false, "Unexpected result!")
@@ -271,7 +272,7 @@ describe(`#address`, () => {
     it(`should GET transactions for a single address`, async () => {
       const addr = "bitcoincash:qz7teqlcltdhqjn2an8nspu7g2x6g3d3rcq8nk4nzs"
 
-      const result = await BITBOX.Address.transactions(addr)
+      const result = await bitbox.Address.transactions(addr)
       //console.log(`result: ${JSON.stringify(result, null, 2)}`)
 
       assert.hasAllKeys(result, [
@@ -304,7 +305,7 @@ describe(`#address`, () => {
         "bitcoincash:qqcp8fw06dmjd2gnfanpwytj7q93w408nv7usdqgsk"
       ]
 
-      const result = await BITBOX.Address.transactions(addr)
+      const result = await bitbox.Address.transactions(addr)
       //console.log(`result: ${JSON.stringify(result, null, 2)}`)
 
       assert.isArray(result)
@@ -336,7 +337,7 @@ describe(`#address`, () => {
       try {
         const addr = 12345
 
-        await BITBOX.Address.transactions(addr)
+        await bitbox.Address.transactions(addr)
         assert.equal(true, false, "Unexpected result!")
       } catch (err) {
         //console.log(`err: `, err)
@@ -353,7 +354,7 @@ describe(`#address`, () => {
         for (let i = 0; i < 25; i++)
           addr.push("bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf")
 
-        const result = await BITBOX.Address.transactions(addr)
+        const result = await bitbox.Address.transactions(addr)
 
         console.log(`result: ${util.inspect(result)}`)
         assert.equal(true, false, "Unexpected result!")

--- a/test/integration/address.js
+++ b/test/integration/address.js
@@ -44,7 +44,8 @@ describe(`#address`, () => {
         "legacyAddress",
         "cashAddress",
         "currentPage",
-        "pagesTotal"
+        "pagesTotal",
+        "slpAddress"
       ])
       assert.isArray(result.transactions)
     })
@@ -74,7 +75,8 @@ describe(`#address`, () => {
         "legacyAddress",
         "cashAddress",
         "currentPage",
-        "pagesTotal"
+        "pagesTotal",
+        "slpAddress"
       ])
       assert.isArray(result[0].transactions)
     })
@@ -122,7 +124,8 @@ describe(`#address`, () => {
         "utxos",
         "legacyAddress",
         "cashAddress",
-        "scriptPubKey"
+        "scriptPubKey",
+        "slpAddress"
       ])
       assert.isArray(result.utxos)
       assert.hasAnyKeys(result.utxos[0], [
@@ -149,7 +152,8 @@ describe(`#address`, () => {
         "utxos",
         "legacyAddress",
         "cashAddress",
-        "scriptPubKey"
+        "scriptPubKey",
+        "slpAddress"
       ])
       assert.isArray(result[0].utxos)
       assert.hasAnyKeys(result[0].utxos[0], [
@@ -201,7 +205,13 @@ describe(`#address`, () => {
       const result = await BITBOX.Address.unconfirmed(addr)
       //console.log(`result: ${JSON.stringify(result, null, 2)}`)
 
-      assert.hasAllKeys(result, ["utxos", "legacyAddress", "cashAddress"])
+      assert.hasAllKeys(result, [
+        "utxos",
+        "legacyAddress",
+        "cashAddress",
+        "scriptPubKey",
+        "slpAddress"
+      ])
       assert.isArray(result.utxos)
     })
 
@@ -215,7 +225,13 @@ describe(`#address`, () => {
       //console.log(`result: ${JSON.stringify(result, null, 2)}`)
 
       assert.isArray(result)
-      assert.hasAllKeys(result[0], ["utxos", "legacyAddress", "cashAddress"])
+      assert.hasAllKeys(result[0], [
+        "utxos",
+        "legacyAddress",
+        "cashAddress",
+        "scriptPubKey",
+        "slpAddress"
+      ])
       assert.isArray(result[0].utxos)
     })
 

--- a/test/integration/block.js
+++ b/test/integration/block.js
@@ -1,12 +1,13 @@
 /*
-  Integration tests for the BITBOX. Only covers calls made to
+  Integration tests for the bitbox. Only covers calls made to
   rest.bitcoin.com.
 */
 
 const chai = require("chai")
 const assert = chai.assert
-const BITBOXSDK = require("../../lib/BITBOX").BITBOX
-const BITBOX = new BITBOXSDK()
+
+const BITBOX = require("../../lib/BITBOX").BITBOX
+const bitbox = new BITBOX()
 
 // Inspect utility used for debugging.
 const util = require("util")
@@ -21,7 +22,7 @@ describe(`#block`, () => {
     it(`should GET block details for a given Height`, async () => {
       const block = 500000
 
-      const result = await BITBOX.Block.detailsByHeight(block)
+      const result = await bitbox.Block.detailsByHeight(block)
       //console.log(`result: ${JSON.stringify(result, null, 2)}`)
 
       assert.hasAllKeys(result, [
@@ -48,7 +49,7 @@ describe(`#block`, () => {
     it(`should GET block details for an array of blocks`, async () => {
       const blocks = [500000, 500001]
 
-      const result = await BITBOX.Block.detailsByHeight(blocks)
+      const result = await bitbox.Block.detailsByHeight(blocks)
       //console.log(`result: ${JSON.stringify(result, null, 2)}`)
 
       assert.isArray(result)
@@ -77,7 +78,7 @@ describe(`#block`, () => {
       try {
         const blocks = "asdf"
 
-        await BITBOX.Block.detailsByHeight(blocks)
+        await bitbox.Block.detailsByHeight(blocks)
         assert.equal(true, false, "Unexpected result!")
       } catch (err) {
         //console.log(`err: `, err)
@@ -93,7 +94,7 @@ describe(`#block`, () => {
         const blocks = []
         for (let i = 0; i < 25; i++) blocks.push(500000)
 
-        const result = await BITBOX.Block.detailsByHeight(blocks)
+        const result = await bitbox.Block.detailsByHeight(blocks)
 
         console.log(`result: ${util.inspect(result)}`)
         assert.equal(true, false, "Unexpected result!")
@@ -109,7 +110,7 @@ describe(`#block`, () => {
       const hash =
         "000000000000000005e14d3f9fdfb70745308706615cfa9edca4f4558332b201"
 
-      const result = await BITBOX.Block.detailsByHash(hash)
+      const result = await bitbox.Block.detailsByHash(hash)
       //console.log(`result: ${util.inspect(result)}`)
 
       assert.hasAllKeys(result, [
@@ -139,7 +140,7 @@ describe(`#block`, () => {
         "000000000000000005e14d3f9fdfb70745308706615cfa9edca4f4558332b201"
       ]
 
-      const result = await BITBOX.Block.detailsByHash(hash)
+      const result = await bitbox.Block.detailsByHash(hash)
       //console.log(`result: ${util.inspect(result)}`)
 
       assert.isArray(result)
@@ -168,7 +169,7 @@ describe(`#block`, () => {
       try {
         const hash = 12345
 
-        await BITBOX.Block.detailsByHash(hash)
+        await bitbox.Block.detailsByHash(hash)
         assert.equal(true, false, "Unexpected result!")
       } catch (err) {
         //console.log(`err: `, err)
@@ -188,7 +189,7 @@ describe(`#block`, () => {
           )
         }
 
-        const result = await BITBOX.Block.detailsByHash(data)
+        const result = await bitbox.Block.detailsByHash(data)
 
         console.log(`result: ${util.inspect(result)}`)
         assert.equal(true, false, "Unexpected result!")

--- a/test/integration/block.js
+++ b/test/integration/block.js
@@ -1,12 +1,12 @@
 /*
-  Integration tests for the bitbox. Only covers calls made to
+  Integration tests for the BITBOX. Only covers calls made to
   rest.bitcoin.com.
 */
 
 const chai = require("chai")
 const assert = chai.assert
-const BITBOX = require("../../lib/BITBOX").BITBOX
-const bitbox = new BITBOX()
+const BITBOXSDK = require("../../lib/BITBOX").BITBOX
+const BITBOX = new BITBOXSDK()
 
 // Inspect utility used for debugging.
 const util = require("util")
@@ -16,4 +16,186 @@ util.inspect.defaultOptions = {
   depth: 3
 }
 
-describe(`#block`, () => {})
+describe(`#block`, () => {
+  describe(`#detailsByHeight`, () => {
+    it(`should GET block details for a given Height`, async () => {
+      const block = 500000
+
+      const result = await BITBOX.Block.detailsByHeight(block)
+      //console.log(`result: ${JSON.stringify(result, null, 2)}`)
+
+      assert.hasAllKeys(result, [
+        "hash",
+        "size",
+        "height",
+        "version",
+        "merkleroot",
+        "tx",
+        "time",
+        "nonce",
+        "bits",
+        "difficulty",
+        "chainwork",
+        "confirmations",
+        "previousblockhash",
+        "nextblockhash",
+        "reward",
+        "isMainChain",
+        "poolInfo"
+      ])
+    })
+
+    it(`should GET block details for an array of blocks`, async () => {
+      const blocks = [500000, 500001]
+
+      const result = await BITBOX.Block.detailsByHeight(blocks)
+      //console.log(`result: ${JSON.stringify(result, null, 2)}`)
+
+      assert.isArray(result)
+      assert.hasAllKeys(result[0], [
+        "hash",
+        "size",
+        "height",
+        "version",
+        "merkleroot",
+        "tx",
+        "time",
+        "nonce",
+        "bits",
+        "difficulty",
+        "chainwork",
+        "confirmations",
+        "previousblockhash",
+        "nextblockhash",
+        "reward",
+        "isMainChain",
+        "poolInfo"
+      ])
+    })
+
+    it(`should throw an error for improper single input`, async () => {
+      try {
+        const blocks = "asdf"
+
+        await BITBOX.Block.detailsByHeight(blocks)
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        //console.log(`err: `, err)
+        assert.include(
+          err.message,
+          `Input must be a number or array of numbers.`
+        )
+      }
+    })
+
+    it(`should throw error on array size rate limit`, async () => {
+      try {
+        const blocks = []
+        for (let i = 0; i < 25; i++) blocks.push(500000)
+
+        const result = await BITBOX.Block.detailsByHeight(blocks)
+
+        console.log(`result: ${util.inspect(result)}`)
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        assert.hasAnyKeys(err, ["error"])
+        assert.include(err.error, "Array too large")
+      }
+    })
+  })
+
+  describe("#detailsByHash", () => {
+    it(`should GET block details for a given hash`, async () => {
+      const hash =
+        "000000000000000005e14d3f9fdfb70745308706615cfa9edca4f4558332b201"
+
+      const result = await BITBOX.Block.detailsByHash(hash)
+      //console.log(`result: ${util.inspect(result)}`)
+
+      assert.hasAllKeys(result, [
+        "hash",
+        "size",
+        "height",
+        "version",
+        "merkleroot",
+        "tx",
+        "time",
+        "nonce",
+        "bits",
+        "difficulty",
+        "chainwork",
+        "confirmations",
+        "previousblockhash",
+        "nextblockhash",
+        "reward",
+        "isMainChain",
+        "poolInfo"
+      ])
+    })
+
+    it(`should GET block details for an array of hashes`, async () => {
+      const hash = [
+        "000000000000000005e14d3f9fdfb70745308706615cfa9edca4f4558332b201",
+        "000000000000000005e14d3f9fdfb70745308706615cfa9edca4f4558332b201"
+      ]
+
+      const result = await BITBOX.Block.detailsByHash(hash)
+      //console.log(`result: ${util.inspect(result)}`)
+
+      assert.isArray(result)
+      assert.hasAllKeys(result[0], [
+        "hash",
+        "size",
+        "height",
+        "version",
+        "merkleroot",
+        "tx",
+        "time",
+        "nonce",
+        "bits",
+        "difficulty",
+        "chainwork",
+        "confirmations",
+        "previousblockhash",
+        "nextblockhash",
+        "reward",
+        "isMainChain",
+        "poolInfo"
+      ])
+    })
+
+    it(`should throw an error for improper single input`, async () => {
+      try {
+        const hash = 12345
+
+        await BITBOX.Block.detailsByHash(hash)
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        //console.log(`err: `, err)
+        assert.include(
+          err.message,
+          `Input must be a string or array of strings`
+        )
+      }
+    })
+
+    it(`should throw error on array size rate limit`, async () => {
+      try {
+        const data = []
+        for (let i = 0; i < 25; i++) {
+          data.push(
+            "000000000000000005e14d3f9fdfb70745308706615cfa9edca4f4558332b201"
+          )
+        }
+
+        const result = await BITBOX.Block.detailsByHash(data)
+
+        console.log(`result: ${util.inspect(result)}`)
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        assert.hasAnyKeys(err, ["error"])
+        assert.include(err.error, "Array too large")
+      }
+    })
+  })
+})

--- a/test/integration/blockchain.js
+++ b/test/integration/blockchain.js
@@ -1,5 +1,5 @@
 /*
-  Integration tests for the bitbox. Only covers calls made to
+  Integration tests for the BITBOX. Only covers calls made to
   rest.bitcoin.com.
 
   TODO
@@ -9,8 +9,8 @@
 
 const chai = require("chai")
 const assert = chai.assert
-const BITBOX = require("../../lib/BITBOX").BITBOX
-const bitbox = new BITBOX()
+const BITBOXSDK = require("../../lib/BITBOX").BITBOX
+const BITBOX = new BITBOXSDK()
 
 // Inspect utility used for debugging.
 const util = require("util")
@@ -20,4 +20,280 @@ util.inspect.defaultOptions = {
   depth: 3
 }
 
-describe(`#blockchain`, () => {})
+describe(`#blockchain`, () => {
+  describe(`#getBestBlockHash`, () => {
+    it(`should GET best block hash`, async () => {
+      const result = await BITBOX.Blockchain.getBestBlockHash()
+      //console.log(`result: ${util.inspect(result)}`)
+
+      assert.isString(result)
+      assert.equal(result.length, 64, "Specific hash length")
+    })
+  })
+
+  describe("#getBlockHeader", () => {
+    it(`should GET block header for a single hash`, async () => {
+      const hash =
+        "000000000000000005e14d3f9fdfb70745308706615cfa9edca4f4558332b201"
+
+      const result = await BITBOX.Blockchain.getBlockHeader(hash)
+
+      assert.hasAllKeys(result, [
+        "hash",
+        "confirmations",
+        "height",
+        "version",
+        "versionHex",
+        "merkleroot",
+        "time",
+        "mediantime",
+        "nonce",
+        "bits",
+        "difficulty",
+        "chainwork",
+        "previousblockhash",
+        "nextblockhash"
+      ])
+    })
+
+    it(`should GET block headers for an array of hashes`, async () => {
+      const hash = [
+        "000000000000000005e14d3f9fdfb70745308706615cfa9edca4f4558332b201",
+        "00000000000000000568f0a96bf4348847bc84e455cbfec389f27311037a20f3"
+      ]
+
+      const result = await BITBOX.Blockchain.getBlockHeader(hash)
+
+      assert.isArray(result)
+      assert.hasAllKeys(result[0], [
+        "hash",
+        "confirmations",
+        "height",
+        "version",
+        "versionHex",
+        "merkleroot",
+        "time",
+        "mediantime",
+        "nonce",
+        "bits",
+        "difficulty",
+        "chainwork",
+        "previousblockhash",
+        "nextblockhash"
+      ])
+    })
+
+    it(`should throw an error for improper input`, async () => {
+      try {
+        const hash = 12345
+
+        await BITBOX.Blockchain.getBlockHeader(hash)
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        assert.include(
+          err.message,
+          `Input hash must be a string or array of strings`
+        )
+      }
+    })
+
+    it(`should throw error on array size rate limit`, async () => {
+      try {
+        const data = []
+        for (let i = 0; i < 25; i++) {
+          data.push(
+            "000000000000000005e14d3f9fdfb70745308706615cfa9edca4f4558332b201"
+          )
+        }
+
+        const result = await BITBOX.Blockchain.getBlockHeader(data)
+
+        console.log(`result: ${util.inspect(result)}`)
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        assert.hasAnyKeys(err, ["error"])
+        assert.include(err.error, "Array too large")
+      }
+    })
+  })
+
+  describe("#getMempoolEntry", () => {
+    /*
+    // To run this test, the txid must be unconfirmed.
+    const txid =
+      "defea04c38ee00cf73ad402984714ed22dc0dd99b2ae5cb50d791d94343ba79b"
+
+    it(`should GET single mempool entry`, async () => {
+      const result = await BITBOX.Blockchain.getMempoolEntry(txid)
+      //console.log(`result: ${JSON.stringify(result, null, 2)}`)
+
+      assert.hasAnyKeys(result, [
+        "size",
+        "fee",
+        "modifiedfee",
+        "time",
+        "height",
+        "startingpriority",
+        "currentpriority",
+        "descendantcount",
+        "descendantsize",
+        "descendantfees",
+        "ancestorcount",
+        "ancestorsize",
+        "ancestorfees",
+        "depends"
+      ])
+    })
+
+    it(`should get an array of mempool entries`, async () => {
+      const result = await BITBOX.Blockchain.getMempoolEntry([txid, txid])
+      console.log(`result: ${JSON.stringify(result, null, 2)}`)
+
+      assert.isArray(result)
+      assert.hasAnyKeys(result[0], [
+        "size",
+        "fee",
+        "modifiedfee",
+        "time",
+        "height",
+        "startingpriority",
+        "currentpriority",
+        "descendantcount",
+        "descendantsize",
+        "descendantfees",
+        "ancestorcount",
+        "ancestorsize",
+        "ancestorfees",
+        "depends"
+      ])
+    })
+    */
+
+    it(`should throw an error if txid is not in mempool`, async () => {
+      try {
+        const txid =
+          "03f69502ca32e7927fd4f38c1d3f950bff650c1eea3d09a70e9df5a9d7f989f7"
+
+        await BITBOX.Blockchain.getMempoolEntry(txid)
+
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        //console.log(`err: ${util.inspect(err)}`)
+        assert.hasAnyKeys(err, ["error"])
+        assert.include(err.error, `Transaction not in mempool`)
+      }
+    })
+
+    it(`should throw an error for improper single input`, async () => {
+      try {
+        const txid = 12345
+
+        await BITBOX.Blockchain.getMempoolEntry(txid)
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        assert.include(
+          err.message,
+          `Input must be a string or array of strings`
+        )
+      }
+    })
+  })
+
+  describe(`#getTxOutProof`, () => {
+    it(`should get single tx out proof`, async () => {
+      const txid =
+        "03f69502ca32e7927fd4f38c1d3f950bff650c1eea3d09a70e9df5a9d7f989f7"
+
+      const result = await BITBOX.Blockchain.getTxOutProof(txid)
+      //console.log(`result: ${JSON.stringify(result, null, 2)}`)
+
+      assert.isString(result)
+    })
+
+    it(`should get an array of tx out proofs`, async () => {
+      const txid = [
+        "03f69502ca32e7927fd4f38c1d3f950bff650c1eea3d09a70e9df5a9d7f989f7",
+        "fe28050b93faea61fa88c4c630f0e1f0a1c24d0082dd0e10d369e13212128f33"
+      ]
+
+      const result = await BITBOX.Blockchain.getTxOutProof(txid)
+      //console.log(`result: ${JSON.stringify(result, null, 2)}`)
+
+      assert.isArray(result)
+      assert.isString(result[0])
+    })
+
+    it(`should throw an error for improper single input`, async () => {
+      try {
+        const txid = 12345
+
+        await BITBOX.Blockchain.getTxOutProof(txid)
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        assert.include(
+          err.message,
+          `Input must be a string or array of strings`
+        )
+      }
+    })
+  })
+
+  describe(`#verifyTxOutProof`, () => {
+    const mockTxOutProof =
+      "0000002086a4a3161f9ba2174883ec0b93acceac3b2f37b36ed1f90000000000000000009cb02406d1094ecf3e0b4c0ca7c585125e721147c39daf6b48c90b512741e13a12333e5cb38705180f441d8c7100000008fee9b60f1edb57e5712839186277ed39e0a004a32be9096ee47472efde8eae62f789f9d7a9f59d0ea7093dea1e0c65ff0b953f1d8cf3d47f92e732ca0295f603c272d5f4a63509f7a887f2549d78af7444aa0ecbb4f66d9cbe13bc6a89f59e05a199df8325d490818ffefe6b6321d32d7496a68580459836c0183f89082fc1b491cc91b23ecdcaa4c347bf599a62904d61f1c15b400ebbd5c90149010c139d9c1e31b774b796977393a238080ab477e1d240d0c4f155d36f519668f49bae6bd8cd5b8e40522edf76faa09cca6188d83ff13af6967cc6a569d1a5e9aeb1fdb7f531ddd2d0cbb81879741d5f38166ac1932136264366a4065cc96a42e41f96294f02df01"
+
+    it(`should verify a single proof`, async () => {
+      const result = await BITBOX.Blockchain.verifyTxOutProof(mockTxOutProof)
+      //console.log(`result: ${JSON.stringify(result, null, 2)}`)
+
+      assert.isArray(result)
+      assert.isString(result[0])
+      assert.equal(
+        result[0],
+        "03f69502ca32e7927fd4f38c1d3f950bff650c1eea3d09a70e9df5a9d7f989f7"
+      )
+    })
+
+    it(`should verify an array of proofs`, async () => {
+      const proofs = [mockTxOutProof, mockTxOutProof]
+      const result = await BITBOX.Blockchain.verifyTxOutProof(proofs)
+      //console.log(`result: ${JSON.stringify(result, null, 2)}`)
+
+      assert.isArray(result)
+      assert.isString(result[0])
+      assert.equal(
+        result[0],
+        "03f69502ca32e7927fd4f38c1d3f950bff650c1eea3d09a70e9df5a9d7f989f7"
+      )
+    })
+
+    it(`should throw an error for improper single input`, async () => {
+      try {
+        const txid = 12345
+
+        await BITBOX.Blockchain.verifyTxOutProof(txid)
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        assert.include(
+          err.message,
+          `Input must be a string or array of strings`
+        )
+      }
+    })
+
+    it(`should throw error on array size rate limit`, async () => {
+      try {
+        const data = []
+        for (let i = 0; i < 25; i++) data.push(mockTxOutProof)
+
+        const result = await BITBOX.Blockchain.verifyTxOutProof(data)
+
+        console.log(`result: ${util.inspect(result)}`)
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        assert.hasAnyKeys(err, ["error"])
+        assert.include(err.error, "Array too large")
+      }
+    })
+  })
+})

--- a/test/integration/blockchain.js
+++ b/test/integration/blockchain.js
@@ -1,5 +1,5 @@
 /*
-  Integration tests for the BITBOX. Only covers calls made to
+  Integration tests for the bitbox. Only covers calls made to
   rest.bitcoin.com.
 
   TODO
@@ -9,8 +9,9 @@
 
 const chai = require("chai")
 const assert = chai.assert
-const BITBOXSDK = require("../../lib/BITBOX").BITBOX
-const BITBOX = new BITBOXSDK()
+
+const BITBOX = require("../../lib/BITBOX").BITBOX
+const bitbox = new BITBOX()
 
 // Inspect utility used for debugging.
 const util = require("util")
@@ -23,7 +24,7 @@ util.inspect.defaultOptions = {
 describe(`#blockchain`, () => {
   describe(`#getBestBlockHash`, () => {
     it(`should GET best block hash`, async () => {
-      const result = await BITBOX.Blockchain.getBestBlockHash()
+      const result = await bitbox.Blockchain.getBestBlockHash()
       //console.log(`result: ${util.inspect(result)}`)
 
       assert.isString(result)
@@ -36,7 +37,7 @@ describe(`#blockchain`, () => {
       const hash =
         "000000000000000005e14d3f9fdfb70745308706615cfa9edca4f4558332b201"
 
-      const result = await BITBOX.Blockchain.getBlockHeader(hash)
+      const result = await bitbox.Blockchain.getBlockHeader(hash)
 
       assert.hasAllKeys(result, [
         "hash",
@@ -62,7 +63,7 @@ describe(`#blockchain`, () => {
         "00000000000000000568f0a96bf4348847bc84e455cbfec389f27311037a20f3"
       ]
 
-      const result = await BITBOX.Blockchain.getBlockHeader(hash)
+      const result = await bitbox.Blockchain.getBlockHeader(hash)
 
       assert.isArray(result)
       assert.hasAllKeys(result[0], [
@@ -87,7 +88,7 @@ describe(`#blockchain`, () => {
       try {
         const hash = 12345
 
-        await BITBOX.Blockchain.getBlockHeader(hash)
+        await bitbox.Blockchain.getBlockHeader(hash)
         assert.equal(true, false, "Unexpected result!")
       } catch (err) {
         assert.include(
@@ -106,7 +107,7 @@ describe(`#blockchain`, () => {
           )
         }
 
-        const result = await BITBOX.Blockchain.getBlockHeader(data)
+        const result = await bitbox.Blockchain.getBlockHeader(data)
 
         console.log(`result: ${util.inspect(result)}`)
         assert.equal(true, false, "Unexpected result!")
@@ -124,7 +125,7 @@ describe(`#blockchain`, () => {
       "defea04c38ee00cf73ad402984714ed22dc0dd99b2ae5cb50d791d94343ba79b"
 
     it(`should GET single mempool entry`, async () => {
-      const result = await BITBOX.Blockchain.getMempoolEntry(txid)
+      const result = await bitbox.Blockchain.getMempoolEntry(txid)
       //console.log(`result: ${JSON.stringify(result, null, 2)}`)
 
       assert.hasAnyKeys(result, [
@@ -146,7 +147,7 @@ describe(`#blockchain`, () => {
     })
 
     it(`should get an array of mempool entries`, async () => {
-      const result = await BITBOX.Blockchain.getMempoolEntry([txid, txid])
+      const result = await bitbox.Blockchain.getMempoolEntry([txid, txid])
       console.log(`result: ${JSON.stringify(result, null, 2)}`)
 
       assert.isArray(result)
@@ -174,7 +175,7 @@ describe(`#blockchain`, () => {
         const txid =
           "03f69502ca32e7927fd4f38c1d3f950bff650c1eea3d09a70e9df5a9d7f989f7"
 
-        await BITBOX.Blockchain.getMempoolEntry(txid)
+        await bitbox.Blockchain.getMempoolEntry(txid)
 
         assert.equal(true, false, "Unexpected result!")
       } catch (err) {
@@ -188,7 +189,7 @@ describe(`#blockchain`, () => {
       try {
         const txid = 12345
 
-        await BITBOX.Blockchain.getMempoolEntry(txid)
+        await bitbox.Blockchain.getMempoolEntry(txid)
         assert.equal(true, false, "Unexpected result!")
       } catch (err) {
         assert.include(
@@ -204,7 +205,7 @@ describe(`#blockchain`, () => {
       const txid =
         "03f69502ca32e7927fd4f38c1d3f950bff650c1eea3d09a70e9df5a9d7f989f7"
 
-      const result = await BITBOX.Blockchain.getTxOutProof(txid)
+      const result = await bitbox.Blockchain.getTxOutProof(txid)
       //console.log(`result: ${JSON.stringify(result, null, 2)}`)
 
       assert.isString(result)
@@ -216,7 +217,7 @@ describe(`#blockchain`, () => {
         "fe28050b93faea61fa88c4c630f0e1f0a1c24d0082dd0e10d369e13212128f33"
       ]
 
-      const result = await BITBOX.Blockchain.getTxOutProof(txid)
+      const result = await bitbox.Blockchain.getTxOutProof(txid)
       //console.log(`result: ${JSON.stringify(result, null, 2)}`)
 
       assert.isArray(result)
@@ -227,7 +228,7 @@ describe(`#blockchain`, () => {
       try {
         const txid = 12345
 
-        await BITBOX.Blockchain.getTxOutProof(txid)
+        await bitbox.Blockchain.getTxOutProof(txid)
         assert.equal(true, false, "Unexpected result!")
       } catch (err) {
         assert.include(
@@ -243,7 +244,7 @@ describe(`#blockchain`, () => {
       "0000002086a4a3161f9ba2174883ec0b93acceac3b2f37b36ed1f90000000000000000009cb02406d1094ecf3e0b4c0ca7c585125e721147c39daf6b48c90b512741e13a12333e5cb38705180f441d8c7100000008fee9b60f1edb57e5712839186277ed39e0a004a32be9096ee47472efde8eae62f789f9d7a9f59d0ea7093dea1e0c65ff0b953f1d8cf3d47f92e732ca0295f603c272d5f4a63509f7a887f2549d78af7444aa0ecbb4f66d9cbe13bc6a89f59e05a199df8325d490818ffefe6b6321d32d7496a68580459836c0183f89082fc1b491cc91b23ecdcaa4c347bf599a62904d61f1c15b400ebbd5c90149010c139d9c1e31b774b796977393a238080ab477e1d240d0c4f155d36f519668f49bae6bd8cd5b8e40522edf76faa09cca6188d83ff13af6967cc6a569d1a5e9aeb1fdb7f531ddd2d0cbb81879741d5f38166ac1932136264366a4065cc96a42e41f96294f02df01"
 
     it(`should verify a single proof`, async () => {
-      const result = await BITBOX.Blockchain.verifyTxOutProof(mockTxOutProof)
+      const result = await bitbox.Blockchain.verifyTxOutProof(mockTxOutProof)
       //console.log(`result: ${JSON.stringify(result, null, 2)}`)
 
       assert.isArray(result)
@@ -256,7 +257,7 @@ describe(`#blockchain`, () => {
 
     it(`should verify an array of proofs`, async () => {
       const proofs = [mockTxOutProof, mockTxOutProof]
-      const result = await BITBOX.Blockchain.verifyTxOutProof(proofs)
+      const result = await bitbox.Blockchain.verifyTxOutProof(proofs)
       //console.log(`result: ${JSON.stringify(result, null, 2)}`)
 
       assert.isArray(result)
@@ -271,7 +272,7 @@ describe(`#blockchain`, () => {
       try {
         const txid = 12345
 
-        await BITBOX.Blockchain.verifyTxOutProof(txid)
+        await bitbox.Blockchain.verifyTxOutProof(txid)
         assert.equal(true, false, "Unexpected result!")
       } catch (err) {
         assert.include(
@@ -286,7 +287,7 @@ describe(`#blockchain`, () => {
         const data = []
         for (let i = 0; i < 25; i++) data.push(mockTxOutProof)
 
-        const result = await BITBOX.Blockchain.verifyTxOutProof(data)
+        const result = await bitbox.Blockchain.verifyTxOutProof(data)
 
         console.log(`result: ${util.inspect(result)}`)
         assert.equal(true, false, "Unexpected result!")

--- a/test/integration/rawtransaction.js
+++ b/test/integration/rawtransaction.js
@@ -1,5 +1,5 @@
 /*
-  Integration tests for the bitbox. Only covers calls made to
+  Integration tests for the BITBOX. Only covers calls made to
   rest.bitcoin.com.
 
   TODO
@@ -7,8 +7,8 @@
 
 const chai = require("chai")
 const assert = chai.assert
-const BITBOX = require("../../lib/BITBOX").BITBOX
-const bitbox = new BITBOX()
+const BITBOXSDK = require("../../lib/BITBOX").BITBOX
+const BITBOX = new BITBOXSDK()
 
 // Inspect utility used for debugging.
 const util = require("util")
@@ -18,4 +18,310 @@ util.inspect.defaultOptions = {
   depth: 3
 }
 
-describe("#rawtransaction", () => {})
+describe("#rawtransaction", () => {
+  describe("#decodeRawTransaction", () => {
+    it("should decode tx for a single hex", async () => {
+      const hex =
+        "0200000001b9b598d7d6d72fc486b2b3a3c03c79b5bade6ec9a77ced850515ab5e64edcc21010000006b483045022100a7b1b08956abb8d6f322aa709d8583c8ea492ba0585f1a6f4f9983520af74a5a0220411aee4a9a54effab617b0508c504c31681b15f9b187179b4874257badd4139041210360cfc66fdacb650bc4c83b4e351805181ee696b7d5ab4667c57b2786f51c413dffffffff0210270000000000001976a914eb4b180def88e3f5625b2d8ae2c098ff7d85f66488ac786e9800000000001976a914eb4b180def88e3f5625b2d8ae2c098ff7d85f66488ac00000000"
+
+      const result = await BITBOX.RawTransactions.decodeRawTransaction(hex)
+      //console.log(`result ${JSON.stringify(result, null, 2)}`)
+
+      assert.hasAnyKeys(result, [
+        "txid",
+        "hash",
+        "size",
+        "version",
+        "locktime",
+        "vin",
+        "vout"
+      ])
+      assert.isArray(result.vin)
+      assert.isArray(result.vout)
+    })
+
+    it("should decode an array of tx hexes", async () => {
+      const hexes = [
+        "0200000001b9b598d7d6d72fc486b2b3a3c03c79b5bade6ec9a77ced850515ab5e64edcc21010000006b483045022100a7b1b08956abb8d6f322aa709d8583c8ea492ba0585f1a6f4f9983520af74a5a0220411aee4a9a54effab617b0508c504c31681b15f9b187179b4874257badd4139041210360cfc66fdacb650bc4c83b4e351805181ee696b7d5ab4667c57b2786f51c413dffffffff0210270000000000001976a914eb4b180def88e3f5625b2d8ae2c098ff7d85f66488ac786e9800000000001976a914eb4b180def88e3f5625b2d8ae2c098ff7d85f66488ac00000000",
+        "0200000001b9b598d7d6d72fc486b2b3a3c03c79b5bade6ec9a77ced850515ab5e64edcc21010000006b483045022100a7b1b08956abb8d6f322aa709d8583c8ea492ba0585f1a6f4f9983520af74a5a0220411aee4a9a54effab617b0508c504c31681b15f9b187179b4874257badd4139041210360cfc66fdacb650bc4c83b4e351805181ee696b7d5ab4667c57b2786f51c413dffffffff0210270000000000001976a914eb4b180def88e3f5625b2d8ae2c098ff7d85f66488ac786e9800000000001976a914eb4b180def88e3f5625b2d8ae2c098ff7d85f66488ac00000000"
+      ]
+
+      const result = await BITBOX.RawTransactions.decodeRawTransaction(hexes)
+      //console.log(`result ${JSON.stringify(result, null, 2)}`)
+
+      assert.isArray(result)
+      assert.hasAnyKeys(result[0], [
+        "txid",
+        "hash",
+        "size",
+        "version",
+        "locktime",
+        "vin",
+        "vout"
+      ])
+      assert.isArray(result[0].vin)
+      assert.isArray(result[0].vout)
+    })
+
+    it(`should throw an error for improper single input`, async () => {
+      try {
+        const addr = 12345
+
+        await BITBOX.RawTransactions.decodeRawTransaction(addr)
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        //console.log(`err: `, err)
+        assert.include(
+          err.message,
+          `Input must be a string or array of strings.`
+        )
+      }
+    })
+
+    it(`should throw error on array size rate limit`, async () => {
+      try {
+        const data = []
+        for (let i = 0; i < 25; i++) {
+          data.push(
+            "0200000001b9b598d7d6d72fc486b2b3a3c03c79b5bade6ec9a77ced850515ab5e64edcc21010000006b483045022100a7b1b08956abb8d6f322aa709d8583c8ea492ba0585f1a6f4f9983520af74a5a0220411aee4a9a54effab617b0508c504c31681b15f9b187179b4874257badd4139041210360cfc66fdacb650bc4c83b4e351805181ee696b7d5ab4667c57b2786f51c413dffffffff0210270000000000001976a914eb4b180def88e3f5625b2d8ae2c098ff7d85f66488ac786e9800000000001976a914eb4b180def88e3f5625b2d8ae2c098ff7d85f66488ac00000000"
+          )
+        }
+
+        const result = await BITBOX.RawTransactions.decodeRawTransaction(data)
+
+        console.log(`result: ${util.inspect(result)}`)
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        assert.hasAnyKeys(err, ["error"])
+        assert.include(err.error, "Array too large")
+      }
+    })
+  })
+
+  describe("#getRawTransaction", () => {
+    it("should decode a single txid, with concise output", async () => {
+      const txid =
+        "23213453b4642a73b4fc30d3112d72549ca153a8707255b14373b59e43558de1"
+      const verbose = false
+
+      const result = await BITBOX.RawTransactions.getRawTransaction(
+        txid,
+        verbose
+      )
+      //console.log(`result: ${JSON.stringify(result, null, 2)}`)
+
+      assert.isString(result)
+    })
+
+    it("should decode a single txid, with verbose output", async () => {
+      const txid =
+        "23213453b4642a73b4fc30d3112d72549ca153a8707255b14373b59e43558de1"
+      const verbose = true
+
+      const result = await BITBOX.RawTransactions.getRawTransaction(
+        txid,
+        verbose
+      )
+      //console.log(`result: ${JSON.stringify(result, null, 2)}`)
+
+      assert.hasAnyKeys(result, [
+        "hex",
+        "txid",
+        "hash",
+        "size",
+        "version",
+        "locktime",
+        "vin",
+        "vout",
+        "blockhash",
+        "confirmations",
+        "time",
+        "blocktime"
+      ])
+      assert.isArray(result.vin)
+      assert.isArray(result.vout)
+    })
+
+    it("should decode an array of txids, with a concise output", async () => {
+      const txid = [
+        "23213453b4642a73b4fc30d3112d72549ca153a8707255b14373b59e43558de1",
+        "b25d24fbb42d84812ed2cb55797f10fdec41afc7906ab563d1ec8c8676a2037f"
+      ]
+      const verbose = false
+
+      const result = await BITBOX.RawTransactions.getRawTransaction(
+        txid,
+        verbose
+      )
+      //console.log(`result: ${JSON.stringify(result, null, 2)}`)
+
+      assert.isArray(result)
+      assert.isString(result[0])
+    })
+
+    it("should decode an array of txids, with a verbose output", async () => {
+      const txid = [
+        "23213453b4642a73b4fc30d3112d72549ca153a8707255b14373b59e43558de1",
+        "b25d24fbb42d84812ed2cb55797f10fdec41afc7906ab563d1ec8c8676a2037f"
+      ]
+      const verbose = true
+
+      const result = await BITBOX.RawTransactions.getRawTransaction(
+        txid,
+        verbose
+      )
+      //console.log(`result: ${JSON.stringify(result, null, 2)}`)
+
+      assert.isArray(result)
+      assert.hasAnyKeys(result[0], [
+        "hex",
+        "txid",
+        "hash",
+        "size",
+        "version",
+        "locktime",
+        "vin",
+        "vout",
+        "blockhash",
+        "confirmations",
+        "time",
+        "blocktime"
+      ])
+      assert.isArray(result[0].vin)
+      assert.isArray(result[0].vout)
+    })
+
+    it(`should throw error on array size rate limit`, async () => {
+      try {
+        const dataMock =
+          "23213453b4642a73b4fc30d3112d72549ca153a8707255b14373b59e43558de1"
+        const data = []
+        for (let i = 0; i < 25; i++) data.push(dataMock)
+
+        const result = await BITBOX.RawTransactions.getRawTransaction(data)
+
+        console.log(`result: ${util.inspect(result)}`)
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        assert.hasAnyKeys(err, ["error"])
+        assert.include(err.error, "Array too large")
+      }
+    })
+  })
+
+  describe("#decodeScript", () => {
+    it("should decode script for a single hex", async () => {
+      const hex =
+        "4830450221009a51e00ec3524a7389592bc27bea4af5104a59510f5f0cfafa64bbd5c164ca2e02206c2a8bbb47eabdeed52f17d7df668d521600286406930426e3a9415fe10ed592012102e6e1423f7abde8b70bca3e78a7d030e5efabd3eb35c19302542b5fe7879c1a16"
+
+      const result = await BITBOX.RawTransactions.decodeScript(hex)
+      //console.log(`result ${JSON.stringify(result, null, 2)}`)
+
+      assert.hasAllKeys(result, ["asm", "type", "p2sh"])
+    })
+
+    // CT 2/20/19 - Waiting for this PR to be merged complete the test:
+    // https://github.com/Bitcoin-com/rest.bitcoin.com/pull/312
+    /*
+    it("should decode an array of tx hexes", async () => {
+      const hexes = [
+        "4830450221009a51e00ec3524a7389592bc27bea4af5104a59510f5f0cfafa64bbd5c164ca2e02206c2a8bbb47eabdeed52f17d7df668d521600286406930426e3a9415fe10ed592012102e6e1423f7abde8b70bca3e78a7d030e5efabd3eb35c19302542b5fe7879c1a16",
+        "4830450221009a51e00ec3524a7389592bc27bea4af5104a59510f5f0cfafa64bbd5c164ca2e02206c2a8bbb47eabdeed52f17d7df668d521600286406930426e3a9415fe10ed592012102e6e1423f7abde8b70bca3e78a7d030e5efabd3eb35c19302542b5fe7879c1a16"
+      ]
+
+      const result = await BITBOX.RawTransactions.decodeScript(hexes)
+      console.log(`result ${JSON.stringify(result, null, 2)}`)
+    })
+*/
+    /*
+    it(`should throw an error for improper single input`, async () => {
+      try {
+        const addr = 12345
+
+        await BITBOX.RawTransactions.decodeRawTransaction(addr)
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        //console.log(`err: `, err)
+        assert.include(
+          err.message,
+          `Input must be a string or array of strings.`
+        )
+      }
+    })
+*/
+  })
+
+  /*
+    Testing sentRawTransaction isn't really possible with an integration test,
+    as the endpoint really needs an e2e test to be properly tested. The tests
+    below expect error messages returned from the server, but at least test
+    that the server is responding on those endpoints, and responds consistently.
+  */
+  describe("sendRawTransaction", () => {
+    it("should send a single transaction hex", async () => {
+      try {
+        const hex =
+          "01000000013ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a000000006a4730440220540986d1c58d6e76f8f05501c520c38ce55393d0ed7ed3c3a82c69af04221232022058ea43ed6c05fec0eccce749a63332ed4525460105346f11108b9c26df93cd72012103083dfc5a0254613941ddc91af39ff90cd711cdcde03a87b144b883b524660c39ffffffff01807c814a000000001976a914d7e7c4e0b70eaa67ceff9d2823d1bbb9f6df9a5188ac00000000"
+
+        await BITBOX.RawTransactions.sendRawTransaction(hex)
+        //console.log(`result ${JSON.stringify(result, null, 2)}`)
+
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        //console.log(`err: ${util.inspect(err)}`)
+
+        assert.hasAllKeys(err, ["error"])
+        assert.include(err.error, "Missing inputs")
+      }
+    })
+
+    it("should send an array of tx hexes", async () => {
+      try {
+        const hexes = [
+          "01000000013ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a000000006a4730440220540986d1c58d6e76f8f05501c520c38ce55393d0ed7ed3c3a82c69af04221232022058ea43ed6c05fec0eccce749a63332ed4525460105346f11108b9c26df93cd72012103083dfc5a0254613941ddc91af39ff90cd711cdcde03a87b144b883b524660c39ffffffff01807c814a000000001976a914d7e7c4e0b70eaa67ceff9d2823d1bbb9f6df9a5188ac00000000",
+          "01000000013ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a000000006a4730440220540986d1c58d6e76f8f05501c520c38ce55393d0ed7ed3c3a82c69af04221232022058ea43ed6c05fec0eccce749a63332ed4525460105346f11108b9c26df93cd72012103083dfc5a0254613941ddc91af39ff90cd711cdcde03a87b144b883b524660c39ffffffff01807c814a000000001976a914d7e7c4e0b70eaa67ceff9d2823d1bbb9f6df9a5188ac00000000"
+        ]
+
+        const result = await BITBOX.RawTransactions.sendRawTransaction(hexes)
+        console.log(`result ${JSON.stringify(result, null, 2)}`)
+      } catch (err) {
+        // console.log(`err: ${util.inspect(err)}`)
+
+        assert.hasAllKeys(err, ["error"])
+        assert.include(err.error, "Missing inputs")
+      }
+    })
+
+    it(`should throw an error for improper single input`, async () => {
+      try {
+        const addr = 12345
+
+        await BITBOX.RawTransactions.sendRawTransaction(addr)
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        //console.log(`err: `, err)
+        assert.include(
+          err.message,
+          `Input hex must be a string or array of strings`
+        )
+      }
+    })
+
+    it(`should throw error on array size rate limit`, async () => {
+      try {
+        const dataMock =
+          "01000000013ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a000000006a4730440220540986d1c58d6e76f8f05501c520c38ce55393d0ed7ed3c3a82c69af04221232022058ea43ed6c05fec0eccce749a63332ed4525460105346f11108b9c26df93cd72012103083dfc5a0254613941ddc91af39ff90cd711cdcde03a87b144b883b524660c39ffffffff01807c814a000000001976a914d7e7c4e0b70eaa67ceff9d2823d1bbb9f6df9a5188ac00000000"
+        const data = []
+        for (let i = 0; i < 25; i++) data.push(dataMock)
+
+        const result = await BITBOX.RawTransactions.sendRawTransaction(data)
+
+        console.log(`result: ${util.inspect(result)}`)
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        assert.hasAnyKeys(err, ["error"])
+        assert.include(err.error, "Array too large")
+      }
+    })
+  })
+})

--- a/test/integration/rawtransaction.js
+++ b/test/integration/rawtransaction.js
@@ -1,5 +1,5 @@
 /*
-  Integration tests for the BITBOX. Only covers calls made to
+  Integration tests for the bitbox. Only covers calls made to
   rest.bitcoin.com.
 
   TODO
@@ -7,8 +7,9 @@
 
 const chai = require("chai")
 const assert = chai.assert
-const BITBOXSDK = require("../../lib/BITBOX").BITBOX
-const BITBOX = new BITBOXSDK()
+
+const BITBOX = require("../../lib/BITBOX").BITBOX
+const bitbox = new BITBOX()
 
 // Inspect utility used for debugging.
 const util = require("util")
@@ -24,7 +25,7 @@ describe("#rawtransaction", () => {
       const hex =
         "0200000001b9b598d7d6d72fc486b2b3a3c03c79b5bade6ec9a77ced850515ab5e64edcc21010000006b483045022100a7b1b08956abb8d6f322aa709d8583c8ea492ba0585f1a6f4f9983520af74a5a0220411aee4a9a54effab617b0508c504c31681b15f9b187179b4874257badd4139041210360cfc66fdacb650bc4c83b4e351805181ee696b7d5ab4667c57b2786f51c413dffffffff0210270000000000001976a914eb4b180def88e3f5625b2d8ae2c098ff7d85f66488ac786e9800000000001976a914eb4b180def88e3f5625b2d8ae2c098ff7d85f66488ac00000000"
 
-      const result = await BITBOX.RawTransactions.decodeRawTransaction(hex)
+      const result = await bitbox.RawTransactions.decodeRawTransaction(hex)
       //console.log(`result ${JSON.stringify(result, null, 2)}`)
 
       assert.hasAnyKeys(result, [
@@ -46,7 +47,7 @@ describe("#rawtransaction", () => {
         "0200000001b9b598d7d6d72fc486b2b3a3c03c79b5bade6ec9a77ced850515ab5e64edcc21010000006b483045022100a7b1b08956abb8d6f322aa709d8583c8ea492ba0585f1a6f4f9983520af74a5a0220411aee4a9a54effab617b0508c504c31681b15f9b187179b4874257badd4139041210360cfc66fdacb650bc4c83b4e351805181ee696b7d5ab4667c57b2786f51c413dffffffff0210270000000000001976a914eb4b180def88e3f5625b2d8ae2c098ff7d85f66488ac786e9800000000001976a914eb4b180def88e3f5625b2d8ae2c098ff7d85f66488ac00000000"
       ]
 
-      const result = await BITBOX.RawTransactions.decodeRawTransaction(hexes)
+      const result = await bitbox.RawTransactions.decodeRawTransaction(hexes)
       //console.log(`result ${JSON.stringify(result, null, 2)}`)
 
       assert.isArray(result)
@@ -67,7 +68,7 @@ describe("#rawtransaction", () => {
       try {
         const addr = 12345
 
-        await BITBOX.RawTransactions.decodeRawTransaction(addr)
+        await bitbox.RawTransactions.decodeRawTransaction(addr)
         assert.equal(true, false, "Unexpected result!")
       } catch (err) {
         //console.log(`err: `, err)
@@ -87,7 +88,7 @@ describe("#rawtransaction", () => {
           )
         }
 
-        const result = await BITBOX.RawTransactions.decodeRawTransaction(data)
+        const result = await bitbox.RawTransactions.decodeRawTransaction(data)
 
         console.log(`result: ${util.inspect(result)}`)
         assert.equal(true, false, "Unexpected result!")
@@ -104,7 +105,7 @@ describe("#rawtransaction", () => {
         "23213453b4642a73b4fc30d3112d72549ca153a8707255b14373b59e43558de1"
       const verbose = false
 
-      const result = await BITBOX.RawTransactions.getRawTransaction(
+      const result = await bitbox.RawTransactions.getRawTransaction(
         txid,
         verbose
       )
@@ -118,7 +119,7 @@ describe("#rawtransaction", () => {
         "23213453b4642a73b4fc30d3112d72549ca153a8707255b14373b59e43558de1"
       const verbose = true
 
-      const result = await BITBOX.RawTransactions.getRawTransaction(
+      const result = await bitbox.RawTransactions.getRawTransaction(
         txid,
         verbose
       )
@@ -149,7 +150,7 @@ describe("#rawtransaction", () => {
       ]
       const verbose = false
 
-      const result = await BITBOX.RawTransactions.getRawTransaction(
+      const result = await bitbox.RawTransactions.getRawTransaction(
         txid,
         verbose
       )
@@ -166,7 +167,7 @@ describe("#rawtransaction", () => {
       ]
       const verbose = true
 
-      const result = await BITBOX.RawTransactions.getRawTransaction(
+      const result = await bitbox.RawTransactions.getRawTransaction(
         txid,
         verbose
       )
@@ -198,7 +199,7 @@ describe("#rawtransaction", () => {
         const data = []
         for (let i = 0; i < 25; i++) data.push(dataMock)
 
-        const result = await BITBOX.RawTransactions.getRawTransaction(data)
+        const result = await bitbox.RawTransactions.getRawTransaction(data)
 
         console.log(`result: ${util.inspect(result)}`)
         assert.equal(true, false, "Unexpected result!")
@@ -214,7 +215,7 @@ describe("#rawtransaction", () => {
       const hex =
         "4830450221009a51e00ec3524a7389592bc27bea4af5104a59510f5f0cfafa64bbd5c164ca2e02206c2a8bbb47eabdeed52f17d7df668d521600286406930426e3a9415fe10ed592012102e6e1423f7abde8b70bca3e78a7d030e5efabd3eb35c19302542b5fe7879c1a16"
 
-      const result = await BITBOX.RawTransactions.decodeScript(hex)
+      const result = await bitbox.RawTransactions.decodeScript(hex)
       //console.log(`result ${JSON.stringify(result, null, 2)}`)
 
       assert.hasAllKeys(result, ["asm", "type", "p2sh"])
@@ -229,7 +230,7 @@ describe("#rawtransaction", () => {
         "4830450221009a51e00ec3524a7389592bc27bea4af5104a59510f5f0cfafa64bbd5c164ca2e02206c2a8bbb47eabdeed52f17d7df668d521600286406930426e3a9415fe10ed592012102e6e1423f7abde8b70bca3e78a7d030e5efabd3eb35c19302542b5fe7879c1a16"
       ]
 
-      const result = await BITBOX.RawTransactions.decodeScript(hexes)
+      const result = await bitbox.RawTransactions.decodeScript(hexes)
       console.log(`result ${JSON.stringify(result, null, 2)}`)
     })
 */
@@ -238,7 +239,7 @@ describe("#rawtransaction", () => {
       try {
         const addr = 12345
 
-        await BITBOX.RawTransactions.decodeRawTransaction(addr)
+        await bitbox.RawTransactions.decodeRawTransaction(addr)
         assert.equal(true, false, "Unexpected result!")
       } catch (err) {
         //console.log(`err: `, err)
@@ -263,7 +264,7 @@ describe("#rawtransaction", () => {
         const hex =
           "01000000013ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a000000006a4730440220540986d1c58d6e76f8f05501c520c38ce55393d0ed7ed3c3a82c69af04221232022058ea43ed6c05fec0eccce749a63332ed4525460105346f11108b9c26df93cd72012103083dfc5a0254613941ddc91af39ff90cd711cdcde03a87b144b883b524660c39ffffffff01807c814a000000001976a914d7e7c4e0b70eaa67ceff9d2823d1bbb9f6df9a5188ac00000000"
 
-        await BITBOX.RawTransactions.sendRawTransaction(hex)
+        await bitbox.RawTransactions.sendRawTransaction(hex)
         //console.log(`result ${JSON.stringify(result, null, 2)}`)
 
         assert.equal(true, false, "Unexpected result!")
@@ -282,7 +283,7 @@ describe("#rawtransaction", () => {
           "01000000013ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a000000006a4730440220540986d1c58d6e76f8f05501c520c38ce55393d0ed7ed3c3a82c69af04221232022058ea43ed6c05fec0eccce749a63332ed4525460105346f11108b9c26df93cd72012103083dfc5a0254613941ddc91af39ff90cd711cdcde03a87b144b883b524660c39ffffffff01807c814a000000001976a914d7e7c4e0b70eaa67ceff9d2823d1bbb9f6df9a5188ac00000000"
         ]
 
-        const result = await BITBOX.RawTransactions.sendRawTransaction(hexes)
+        const result = await bitbox.RawTransactions.sendRawTransaction(hexes)
         console.log(`result ${JSON.stringify(result, null, 2)}`)
       } catch (err) {
         // console.log(`err: ${util.inspect(err)}`)
@@ -296,7 +297,7 @@ describe("#rawtransaction", () => {
       try {
         const addr = 12345
 
-        await BITBOX.RawTransactions.sendRawTransaction(addr)
+        await bitbox.RawTransactions.sendRawTransaction(addr)
         assert.equal(true, false, "Unexpected result!")
       } catch (err) {
         //console.log(`err: `, err)
@@ -314,7 +315,7 @@ describe("#rawtransaction", () => {
         const data = []
         for (let i = 0; i < 25; i++) data.push(dataMock)
 
-        const result = await BITBOX.RawTransactions.sendRawTransaction(data)
+        const result = await bitbox.RawTransactions.sendRawTransaction(data)
 
         console.log(`result: ${util.inspect(result)}`)
         assert.equal(true, false, "Unexpected result!")

--- a/test/integration/transaction.js
+++ b/test/integration/transaction.js
@@ -1,12 +1,13 @@
 /*
-  Integration tests for the BITBOX. Only covers calls made to
+  Integration tests for the bitbox. Only covers calls made to
   rest.bitcoin.com.
 */
 
 const chai = require("chai")
 const assert = chai.assert
-const BITBOXSDK = require("../../lib/BITBOX").BITBOX
-const BITBOX = new BITBOXSDK()
+
+const BITBOX = require("../../lib/BITBOX").BITBOX
+const bitbox = new BITBOX()
 
 // Inspect utility used for debugging.
 const util = require("util")
@@ -22,7 +23,7 @@ describe(`#Transaction`, () => {
       const txid =
         "fe28050b93faea61fa88c4c630f0e1f0a1c24d0082dd0e10d369e13212128f33"
 
-      const result = await BITBOX.Transaction.details(txid)
+      const result = await bitbox.Transaction.details(txid)
       //console.log(`result: ${JSON.stringify(result, null, 2)}`)
 
       assert.hasAllKeys(result, [
@@ -48,7 +49,7 @@ describe(`#Transaction`, () => {
         "fe28050b93faea61fa88c4c630f0e1f0a1c24d0082dd0e10d369e13212128f33"
       ]
 
-      const result = await BITBOX.Transaction.details(txids)
+      const result = await bitbox.Transaction.details(txids)
       //console.log(`result: ${JSON.stringify(result, null, 2)}`)
 
       assert.isArray(result)
@@ -58,7 +59,7 @@ describe(`#Transaction`, () => {
       try {
         const txid = 12345
 
-        await BITBOX.Transaction.details(txid)
+        await bitbox.Transaction.details(txid)
         assert.equal(true, false, "Unexpected result!")
       } catch (err) {
         //console.log(`err: `, err)
@@ -76,7 +77,7 @@ describe(`#Transaction`, () => {
         const data = []
         for (let i = 0; i < 25; i++) data.push(dataMock)
 
-        const result = await BITBOX.Transaction.details(data)
+        const result = await bitbox.Transaction.details(data)
 
         // console.log(`result: ${util.inspect(result)}`)
         assert.equal(false, false, "Unexpected result!")

--- a/test/integration/transaction.js
+++ b/test/integration/transaction.js
@@ -1,12 +1,12 @@
 /*
-  Integration tests for the bitbox. Only covers calls made to
+  Integration tests for the BITBOX. Only covers calls made to
   rest.bitcoin.com.
 */
 
 const chai = require("chai")
 const assert = chai.assert
-const BITBOX = require("../../lib/BITBOX").BITBOX
-const bitbox = new BITBOX()
+const BITBOXSDK = require("../../lib/BITBOX").BITBOX
+const BITBOX = new BITBOXSDK()
 
 // Inspect utility used for debugging.
 const util = require("util")
@@ -16,4 +16,76 @@ util.inspect.defaultOptions = {
   depth: 3
 }
 
-describe(`#Transaction`, () => {})
+describe(`#Transaction`, () => {
+  describe(`#details`, () => {
+    it(`should GET details for a given txid`, async () => {
+      const txid =
+        "fe28050b93faea61fa88c4c630f0e1f0a1c24d0082dd0e10d369e13212128f33"
+
+      const result = await BITBOX.Transaction.details(txid)
+      //console.log(`result: ${JSON.stringify(result, null, 2)}`)
+
+      assert.hasAllKeys(result, [
+        "txid",
+        "version",
+        "locktime",
+        "vin",
+        "vout",
+        "blockhash",
+        "blockheight",
+        "confirmations",
+        "time",
+        "blocktime",
+        "isCoinBase",
+        "valueOut",
+        "size"
+      ])
+    })
+
+    it(`should GET details for an array of txids`, async () => {
+      const txids = [
+        "fe28050b93faea61fa88c4c630f0e1f0a1c24d0082dd0e10d369e13212128f33",
+        "fe28050b93faea61fa88c4c630f0e1f0a1c24d0082dd0e10d369e13212128f33"
+      ]
+
+      const result = await BITBOX.Transaction.details(txids)
+      //console.log(`result: ${JSON.stringify(result, null, 2)}`)
+
+      assert.isArray(result)
+    })
+
+    it(`should throw an error for improper single input`, async () => {
+      try {
+        const txid = 12345
+
+        await BITBOX.Transaction.details(txid)
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        //console.log(`err: `, err)
+        assert.include(
+          err.message,
+          `Input txid must be a string or array of strings`
+        )
+      }
+    })
+
+    it(`should throw error on array size rate limit`, async () => {
+      try {
+        const dataMock =
+          "fe28050b93faea61fa88c4c630f0e1f0a1c24d0082dd0e10d369e13212128f33"
+        const data = []
+        for (let i = 0; i < 25; i++) data.push(dataMock)
+
+        const result = await BITBOX.Transaction.details(data)
+
+        // console.log(`result: ${util.inspect(result)}`)
+        assert.equal(false, false, "Unexpected result!")
+      } catch (err) {
+        console.log(`err: ${util.inspect(err)}`)
+
+        assert.hasAnyKeys(err, ["error"])
+        assert.include(err.error, "Array too large")
+      }
+    })
+  })
+})

--- a/test/integration/util.js
+++ b/test/integration/util.js
@@ -1,12 +1,13 @@
 /*
-  Integration tests for the BITBOX. Only covers calls made to
+  Integration tests for the bitbox. Only covers calls made to
   rest.bitcoin.com.
 */
 
 const chai = require("chai")
 const assert = chai.assert
-const BITBOXSDK = require("../../lib/BITBOX").BITBOX
-const BITBOX = new BITBOXSDK()
+
+const BITBOX = require("../../lib/BITBOX").BITBOX
+const bitbox = new BITBOX()
 
 // Inspect utility used for debugging.
 const util = require("util")
@@ -21,7 +22,7 @@ describe(`#util`, () => {
     it(`should return false for testnet addr on mainnet`, async () => {
       const address = `bchtest:qqqk4y6lsl5da64sg5qc3xezmplyu5kmpyz2ysaa5y`
 
-      const result = await BITBOX.Util.validateAddress(address)
+      const result = await bitbox.Util.validateAddress(address)
       //console.log(`result: ${JSON.stringify(result, null, 2)}`)
 
       assert.hasAllKeys(result, ["isvalid"])
@@ -31,7 +32,7 @@ describe(`#util`, () => {
     it(`should return false for bad address`, async () => {
       const address = `bitcoincash:qp4k8fjtgunhdr7yq30ha4peu`
 
-      const result = await BITBOX.Util.validateAddress(address)
+      const result = await bitbox.Util.validateAddress(address)
       //console.log(`result: ${JSON.stringify(result, null, 2)}`)
 
       assert.hasAllKeys(result, ["isvalid"])
@@ -41,7 +42,7 @@ describe(`#util`, () => {
     it(`should return validate valid address`, async () => {
       const address = `bitcoincash:qp4k8fjtgunhdr7yq30ha4peuwupzan2vcnwrmpy0z`
 
-      const result = await BITBOX.Util.validateAddress(address)
+      const result = await bitbox.Util.validateAddress(address)
       //console.log(`result: ${JSON.stringify(result, null, 2)}`)
 
       assert.hasAllKeys(result, [
@@ -61,7 +62,7 @@ describe(`#util`, () => {
         `bitcoincash:qp4k8fjtgunhdr7yq30ha4peuwupzan2vcnwrmpy0z`
       ]
 
-      const result = await BITBOX.Util.validateAddress(address)
+      const result = await bitbox.Util.validateAddress(address)
       //console.log(`result: ${JSON.stringify(result, null, 2)}`)
 
       assert.isArray(result)
@@ -79,7 +80,7 @@ describe(`#util`, () => {
       try {
         const address = 15432
 
-        await BITBOX.Util.validateAddress(address)
+        await bitbox.Util.validateAddress(address)
         assert.equal(true, false, "Unexpected result!")
       } catch (err) {
         //console.log(`err: `, err)
@@ -96,7 +97,7 @@ describe(`#util`, () => {
         const data = []
         for (let i = 0; i < 25; i++) data.push(dataMock)
 
-        const result = await BITBOX.Util.validateAddress(data)
+        const result = await bitbox.Util.validateAddress(data)
 
         console.log(`result: ${util.inspect(result)}`)
         assert.equal(true, false, "Unexpected result!")

--- a/test/integration/util.js
+++ b/test/integration/util.js
@@ -1,12 +1,12 @@
 /*
-  Integration tests for the bitbox. Only covers calls made to
+  Integration tests for the BITBOX. Only covers calls made to
   rest.bitcoin.com.
 */
 
 const chai = require("chai")
 const assert = chai.assert
-const BITBOX = require("../../lib/BITBOX").BITBOX
-const bitbox = new BITBOX()
+const BITBOXSDK = require("../../lib/BITBOX").BITBOX
+const BITBOX = new BITBOXSDK()
 
 // Inspect utility used for debugging.
 const util = require("util")
@@ -16,4 +16,94 @@ util.inspect.defaultOptions = {
   depth: 3
 }
 
-describe(`#util`, () => {})
+describe(`#util`, () => {
+  describe(`#validateAddress`, () => {
+    it(`should return false for testnet addr on mainnet`, async () => {
+      const address = `bchtest:qqqk4y6lsl5da64sg5qc3xezmplyu5kmpyz2ysaa5y`
+
+      const result = await BITBOX.Util.validateAddress(address)
+      //console.log(`result: ${JSON.stringify(result, null, 2)}`)
+
+      assert.hasAllKeys(result, ["isvalid"])
+      assert.equal(result.isvalid, false)
+    })
+
+    it(`should return false for bad address`, async () => {
+      const address = `bitcoincash:qp4k8fjtgunhdr7yq30ha4peu`
+
+      const result = await BITBOX.Util.validateAddress(address)
+      //console.log(`result: ${JSON.stringify(result, null, 2)}`)
+
+      assert.hasAllKeys(result, ["isvalid"])
+      assert.equal(result.isvalid, false)
+    })
+
+    it(`should return validate valid address`, async () => {
+      const address = `bitcoincash:qp4k8fjtgunhdr7yq30ha4peuwupzan2vcnwrmpy0z`
+
+      const result = await BITBOX.Util.validateAddress(address)
+      //console.log(`result: ${JSON.stringify(result, null, 2)}`)
+
+      assert.hasAllKeys(result, [
+        "isvalid",
+        "address",
+        "scriptPubKey",
+        "ismine",
+        "iswatchonly",
+        "isscript"
+      ])
+      assert.equal(result.isvalid, true)
+    })
+
+    it(`should validate an array of addresses`, async () => {
+      const address = [
+        `bitcoincash:qp4k8fjtgunhdr7yq30ha4peuwupzan2vcnwrmpy0z`,
+        `bitcoincash:qp4k8fjtgunhdr7yq30ha4peuwupzan2vcnwrmpy0z`
+      ]
+
+      const result = await BITBOX.Util.validateAddress(address)
+      //console.log(`result: ${JSON.stringify(result, null, 2)}`)
+
+      assert.isArray(result)
+      assert.hasAllKeys(result[0], [
+        "isvalid",
+        "address",
+        "scriptPubKey",
+        "ismine",
+        "iswatchonly",
+        "isscript"
+      ])
+    })
+
+    it(`should throw an error for improper single input`, async () => {
+      try {
+        const address = 15432
+
+        await BITBOX.Util.validateAddress(address)
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        //console.log(`err: `, err)
+        assert.include(
+          err.message,
+          `Input must be a string or array of strings.`
+        )
+      }
+    })
+
+    it(`should throw error on array size rate limit`, async () => {
+      try {
+        const dataMock = `bitcoincash:qp4k8fjtgunhdr7yq30ha4peuwupzan2vcnwrmpy0z`
+        const data = []
+        for (let i = 0; i < 25; i++) data.push(dataMock)
+
+        const result = await BITBOX.Util.validateAddress(data)
+
+        console.log(`result: ${util.inspect(result)}`)
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        assert.hasAnyKeys(err, ["error"])
+        assert.include(err.error, "Array too large")
+      }
+    })
+  })
+})

--- a/test/integration/z9-rate-limits.js
+++ b/test/integration/z9-rate-limits.js
@@ -6,6 +6,7 @@
 
 const chai = require("chai")
 const assert = chai.assert
+
 const BITBOX = require("../../lib/BITBOX").BITBOX
 const bitbox = new BITBOX()
 


### PR DESCRIPTION
Adds integration tests back in. These tests are executed by running:

`npm run test:integration`