### PR TITLE
Address unit tests

### DIFF
--- a/lib/Address.ts
+++ b/lib/Address.ts
@@ -263,14 +263,14 @@ export class Address {
 
         // Handle array of addresses.
       } else if (Array.isArray(address)) {
-        const options: any = {
-          method: "POST",
-          url: `${this.restURL}address/details`,
-          data: {
+
+        // Dev note: must use axios.post for unit test stubbing.
+        const response: AxiosResponse = await axios.post(
+          `${this.restURL}address/details`,
+          {
             addresses: address
           }
-        }
-        const response: AxiosResponse = await axios(options)
+        )
 
         return <AddressDetailsResult>response.data
       }
@@ -293,14 +293,14 @@ export class Address {
         )
         return response.data
       } else if (Array.isArray(address)) {
-        const options: any = {
-          method: "POST",
-          url: `${this.restURL}address/utxo`,
-          data: {
+
+        // Dev note: must use axios.post for unit test stubbing.
+        const response: AxiosResponse = await axios.post(
+          `${this.restURL}address/utxo`,
+          {
             addresses: address
           }
-        }
-        const response: AxiosResponse = await axios(options)
+        )
 
         return response.data
       }

--- a/lib/Address.ts
+++ b/lib/Address.ts
@@ -355,14 +355,14 @@ export class Address {
 
         // Handle an array of addresses
       } else if (Array.isArray(address)) {
-        const options: any = {
-          method: "POST",
-          url: `${this.restURL}address/transactions`,
-          data: {
+
+        // Dev note: must use axios.post for unit test stubbing.
+        const response: AxiosResponse = await axios.post(
+          `${this.restURL}address/transactions`,
+          {
             addresses: address
           }
-        }
-        const response: AxiosResponse = await axios(options)
+        )
 
         return response.data
       }

--- a/lib/Address.ts
+++ b/lib/Address.ts
@@ -325,14 +325,14 @@ export class Address {
 
         // Handle an array of addresses
       } else if (Array.isArray(address)) {
-        const options: any = {
-          method: "POST",
-          url: `${this.restURL}address/unconfirmed`,
-          data: {
+
+        // Dev note: must use axios.post for unit test stubbing.
+        const response: AxiosResponse = await axios.post(
+          `${this.restURL}address/unconfirmed`,
+          {
             addresses: address
           }
-        }
-        const response: AxiosResponse = await axios(options)
+        )
 
         return response.data
       }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   ],
   "scripts": {
     "test": "tsc && nyc mocha test/unit --timeout 60000 --exit",
+    "test:no-build": "nyc mocha test/unit --timeout 60000 --exit",
     "test:integration": "TEST=integration nyc --reporter=text mocha --timeout 30000 test/integration",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "build": "tsc"

--- a/test/unit/Address.ts
+++ b/test/unit/Address.ts
@@ -8,6 +8,8 @@ import * as chai from "chai"
 import { Address } from "../../lib/Address"
 import { BITBOX, resturl } from "../../lib/BITBOX"
 
+import axios from "axios"
+
 // consts
 const bitbox: BITBOX = new BITBOX()
 const assert: Chai.AssertStatic = chai.assert
@@ -15,6 +17,8 @@ const assert: Chai.AssertStatic = chai.assert
 // TODO: port from require to import syntax
 const fixtures = require("./fixtures/Address.json")
 const Bitcoin = require("bitcoincashjs-lib")
+const sinon = require("sinon")
+const addressMock = require("./fixtures/address-mock.js")
 
 function flatten(arrays: any) {
   return [].concat.apply([], arrays)
@@ -101,6 +105,7 @@ util.inspect.defaultOptions = {
 }
 
 describe("#Address", (): void => {
+/*
   describe("#AddressConstructor", (): void => {
     it("should create instance of Address", (): void => {
       const address: Address = new Address()
@@ -1012,7 +1017,7 @@ describe("#Address", (): void => {
     it(`should generate public external change address ${
       XPUBS[0].addresses[0]
     } for ${XPUBS[0].xpub}`, (): void => {
-      let address: string = XPUBS[0].addresses[0]
+      const address: string = XPUBS[0].addresses[0]
       assert.equal(bitbox.Address.fromXPub(XPUBS[0].xpub), address)
     })
   })
@@ -1038,7 +1043,7 @@ describe("#Address", (): void => {
     it(`should generate hardened address ${XPRIVS[0].addresses[0]} for ${
       XPRIVS[0].xpriv
     }`, (): void => {
-      let address: string = XPRIVS[0].addresses[0]
+      const address: string = XPRIVS[0].addresses[0]
       assert.equal(bitbox.Address.fromXPriv(XPRIVS[0].xpriv), address)
     })
   })
@@ -1079,135 +1084,65 @@ describe("#Address", (): void => {
       }
     )
   })
+*/
+  describe("#details", () => {
+    let sandbox: any
+    beforeEach(() => (sandbox = sinon.sandbox.create()))
+    afterEach(() => sandbox.restore())
 
-  // describe("#details", () => {
-  //   let sandbox: any
-  //   beforeEach(() => (sandbox = sinon.sandbox.create()))
-  //   afterEach(() => sandbox.restore())
+    it(`should GET address details for a single address`, async (): Promise<
+      any
+    > => {
 
-  //   it("should get details", done => {
-  //     const data: any = {
-  //       legacyAddress: "3CnzuFFbtgVyHNiDH8BknGo3PQ3dpdThgJ",
-  //       cashAddress: "bitcoincash:ppuukp49np467kyzxl0fkla34rmgcddhvc33ce2d6l",
-  //       balance: 300.0828874,
-  //       balanceSat: 30008288740,
-  //       totalReceived: 12945.45174649,
-  //       totalReceivedSat: 1294545174649,
-  //       totalSent: 12645.36885909,
-  //       totalSentSat: 1264536885909,
-  //       unconfirmedBalance: 0,
-  //       unconfirmedBalanceSat: 0,
-  //       unconfirmedTxApperances: 0,
-  //       txApperances: 1042,
-  //       transactions: [
-  //         "b29425a876f62e114508e67e66b5eb1ab0d320d7c9a57fb0ece086a36e2b7309"
-  //       ]
-  //     }
+      // Mock out data for unit test, to prevent live network call.
+      const data: any = addressMock.details
+      const resolved: any = new Promise(r => r({ data: data }))
+      sandbox.stub(axios, "get").returns(resolved)
 
-  //     const resolved: any = new Promise(r => r({ data: data }))
-  //     sandbox.stub(axios, "get").returns(resolved)
+      const addr: string =
+        "bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf"
 
-  //     bitbox.Address.details(
-  //       "bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf"
-  //     )
-  //       .then((result: any) => {
-  //         assert.deepEqual(data, result)
-  //       })
-  //       .then(done, done)
-  //   })
-  // })
+      const result:
+        | AddressDetailsResult
+        | AddressDetailsResult[] = await bitbox.Address.details(addr)
+      //console.log(`result: ${JSON.stringify(result,null,2)}`)
 
-  // describe("#utxo", () => {
-  //   let sandbox: any
-  //   beforeEach(() => (sandbox = sinon.sandbox.create()))
-  //   afterEach(() => sandbox.restore())
+      assert.hasAllKeys(result, [
+        "balance",
+        "balanceSat",
+        "totalReceived",
+        "totalReceivedSat",
+        "totalSent",
+        "totalSentSat",
+        "unconfirmedBalance",
+        "unconfirmedBalanceSat",
+        "unconfirmedTxApperances",
+        "txApperances",
+        "transactions",
+        "legacyAddress",
+        "cashAddress",
+        "slpAddress",
+        "currentPage",
+        "pagesTotal"
+      ])
+      if (!Array.isArray(result)) assert.isArray(result.transactions)
+    })
 
-  //   it("should get utxo", done => {
-  //     const data = [
-  //       {
-  //         legacyAddress: "3CnzuFFbtgVyHNiDH8BknGo3PQ3dpdThgJ",
-  //         cashAddress: "bitcoincash:ppuukp49np467kyzxl0fkla34rmgcddhvc33ce2d6l",
-  //         txid:
-  //           "6f56254424378d6914cebd097579c70664843e5876ca86f0bf412ba7f3928326",
-  //         vout: 0,
-  //         scriptPubKey: "a91479cb06a5986baf588237de9b7fb1a8f68c35b76687",
-  //         amount: 12.5002911,
-  //         satoshis: 1250029110,
-  //         height: 528745,
-  //         confirmations: 17
-  //       },
-  //       {
-  //         legacyAddress: "3CnzuFFbtgVyHNiDH8BknGo3PQ3dpdThgJ",
-  //         cashAddress: "bitcoincash:ppuukp49np467kyzxl0fkla34rmgcddhvc33ce2d6l",
-  //         txid:
-  //           "b29425a876f62e114508e67e66b5eb1ab0d320d7c9a57fb0ece086a36e2b7309",
-  //         vout: 0,
-  //         scriptPubKey: "a91479cb06a5986baf588237de9b7fb1a8f68c35b76687",
-  //         amount: 12.50069247,
-  //         satoshis: 1250069247,
-  //         height: 528744,
-  //         confirmations: 18
-  //       }
-  //     ]
-  //     const resolved: any = new Promise(r => r({ data: data }))
-  //     sandbox.stub(axios, "get").returns(resolved)
+    it(`should GET address details for an array of addresses`, async (): Promise<
+      any
+    > => {
+      const addr: string[] = [
+        "bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf",
+        "bitcoincash:qpdh9s677ya8tnx7zdhfrn8qfyvy22wj4qa7nwqa5v"
+      ]
 
-  //     bitbox.Address.utxo(
-  //       "bitcoincash:ppuukp49np467kyzxl0fkla34rmgcddhvc33ce2d6l"
-  //     )
-  //       .then((result: any) => {
-  //         assert.deepEqual(data, result)
-  //       })
-  //       .then(done, done)
-  //   })
-  // })
+      const result:
+        | AddressDetailsResult
+        | AddressDetailsResult[] = await bitbox.Address.details(addr)
 
-  // describe("#unconfirmed", () => {
-  //   let sandbox: any
-  //   beforeEach(() => (sandbox = sinon.sandbox.create()))
-  //   afterEach(() => sandbox.restore())
-
-  //   it("should get unconfirmed transactions", done => {
-  //     const data = [
-  //       {
-  //         txid:
-  //           "e0aadd861a06993e39af932bb0b9ad69e7b37ef5843a13c6724789e1c94f3513",
-  //         vout: 1,
-  //         scriptPubKey: "76a914a0f531f4ff810a415580c12e54a7072946bb927e88ac",
-  //         amount: 0.00008273,
-  //         satoshis: 8273,
-  //         confirmations: 0,
-  //         ts: 1526680569,
-  //         legacyAddress: "1Fg4r9iDrEkCcDmHTy2T79EusNfhyQpu7W",
-  //         cashAddress: "bitcoincash:qzs02v05l7qs5s24srqju498qu55dwuj0cx5ehjm2c"
-  //       }
-  //     ]
-  //     const resolved: any = new Promise(r => r({ data: data }))
-  //     sandbox.stub(axios, "get").returns(resolved)
-
-  //     bitbox.Address.unconfirmed(
-  //       "bitcoincash:qzs02v05l7qs5s24srqju498qu55dwuj0cx5ehjm2c"
-  //     )
-  //       .then((result: any) => {
-  //         assert.deepEqual(data, result)
-  //       })
-  //       .then(done, done)
-  //   })
-  // })
-
-  describe(`#utxo`, (): void => {
-    describe(`#details`, (): void => {
-      it(`should GET address details for a single address`, async (): Promise<
-        any
-      > => {
-        const addr: string =
-          "bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf"
-
-        const result:
-          | AddressDetailsResult
-          | AddressDetailsResult[] = await bitbox.Address.details(addr)
-
-        assert.hasAllKeys(result, [
+      assert.isArray(result)
+      if (Array.isArray(result)) {
+        assert.hasAllKeys(result[0], [
           "balance",
           "balanceSat",
           "totalReceived",
@@ -1225,77 +1160,154 @@ describe("#Address", (): void => {
           "currentPage",
           "pagesTotal"
         ])
-        if (!Array.isArray(result)) {
-          assert.isArray(result.transactions)
-        }
-      })
+        assert.isArray(result[0].transactions)
+      }
+    })
 
-      it(`should GET address details for an array of addresses`, async (): Promise<
-        any
-      > => {
-        const addr: string[] = [
-          "bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf",
-          "bitcoincash:qpdh9s677ya8tnx7zdhfrn8qfyvy22wj4qa7nwqa5v"
+    it(`should throw an error for improper input`, async () => {
+      try {
+        const addr: any = 12345
+
+        await bitbox.Address.details(addr)
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        //console.log(`err: `, err)
+        assert.include(
+          err.message,
+          `Input address must be a string or array of strings`
+        )
+      }
+    })
+
+    it(`should throw error on array size rate limit`, async () => {
+      try {
+        const addr = []
+        for (let i = 0; i < 25; i++)
+          addr.push("bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf")
+
+        const result = await bitbox.Address.details(addr)
+
+        console.log(`result: ${util.inspect(result)}`)
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        assert.hasAnyKeys(err, ["error"])
+        assert.include(err.error, "Array too large")
+      }
+    })
+
+    it("should get details", done => {
+      const data: any = {
+        legacyAddress: "3CnzuFFbtgVyHNiDH8BknGo3PQ3dpdThgJ",
+        cashAddress: "bitcoincash:ppuukp49np467kyzxl0fkla34rmgcddhvc33ce2d6l",
+        balance: 300.0828874,
+        balanceSat: 30008288740,
+        totalReceived: 12945.45174649,
+        totalReceivedSat: 1294545174649,
+        totalSent: 12645.36885909,
+        totalSentSat: 1264536885909,
+        unconfirmedBalance: 0,
+        unconfirmedBalanceSat: 0,
+        unconfirmedTxApperances: 0,
+        txApperances: 1042,
+        transactions: [
+          "b29425a876f62e114508e67e66b5eb1ab0d320d7c9a57fb0ece086a36e2b7309"
         ]
+      }
 
-        const result:
-          | AddressDetailsResult
-          | AddressDetailsResult[] = await bitbox.Address.details(addr)
+      const resolved: any = new Promise(r => r({ data: data }))
+      sandbox.stub(axios, "get").returns(resolved)
 
-        assert.isArray(result)
-        if (Array.isArray(result)) {
-          assert.hasAllKeys(result[0], [
-            "balance",
-            "balanceSat",
-            "totalReceived",
-            "totalReceivedSat",
-            "totalSent",
-            "totalSentSat",
-            "unconfirmedBalance",
-            "unconfirmedBalanceSat",
-            "unconfirmedTxApperances",
-            "txApperances",
-            "transactions",
-            "legacyAddress",
-            "cashAddress",
-            "slpAddress",
-            "currentPage",
-            "pagesTotal"
-          ])
-          assert.isArray(result[0].transactions)
+      bitbox.Address.details(
+        "bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf"
+      )
+        .then((result: any) => {
+          assert.deepEqual(data, result)
+        })
+        .then(done, done)
+    })
+  })
+
+  describe("#utxo", () => {
+    let sandbox: any
+    beforeEach(() => (sandbox = sinon.sandbox.create()))
+    afterEach(() => sandbox.restore())
+
+    it("should get utxo", done => {
+      const data = [
+        {
+          legacyAddress: "3CnzuFFbtgVyHNiDH8BknGo3PQ3dpdThgJ",
+          cashAddress: "bitcoincash:ppuukp49np467kyzxl0fkla34rmgcddhvc33ce2d6l",
+          txid:
+            "6f56254424378d6914cebd097579c70664843e5876ca86f0bf412ba7f3928326",
+          vout: 0,
+          scriptPubKey: "a91479cb06a5986baf588237de9b7fb1a8f68c35b76687",
+          amount: 12.5002911,
+          satoshis: 1250029110,
+          height: 528745,
+          confirmations: 17
+        },
+        {
+          legacyAddress: "3CnzuFFbtgVyHNiDH8BknGo3PQ3dpdThgJ",
+          cashAddress: "bitcoincash:ppuukp49np467kyzxl0fkla34rmgcddhvc33ce2d6l",
+          txid:
+            "b29425a876f62e114508e67e66b5eb1ab0d320d7c9a57fb0ece086a36e2b7309",
+          vout: 0,
+          scriptPubKey: "a91479cb06a5986baf588237de9b7fb1a8f68c35b76687",
+          amount: 12.50069247,
+          satoshis: 1250069247,
+          height: 528744,
+          confirmations: 18
         }
-      })
+      ]
+      const resolved: any = new Promise(r => r({ data: data }))
+      sandbox.stub(axios, "get").returns(resolved)
 
-      it(`should throw an error for improper input`, async () => {
-        try {
-          const addr: any = 12345
+      bitbox.Address.utxo(
+        "bitcoincash:ppuukp49np467kyzxl0fkla34rmgcddhvc33ce2d6l"
+      )
+        .then((result: any) => {
+          assert.deepEqual(data, result)
+        })
+        .then(done, done)
+    })
+  })
 
-          await bitbox.Address.details(addr)
-          assert.equal(true, false, "Unexpected result!")
-        } catch (err) {
-          //console.log(`err: `, err)
-          assert.include(
-            err.message,
-            `Input address must be a string or array of strings`
-          )
+  describe("#unconfirmed", () => {
+    let sandbox: any
+    beforeEach(() => (sandbox = sinon.sandbox.create()))
+    afterEach(() => sandbox.restore())
+
+    it("should get unconfirmed transactions", done => {
+      const data = [
+        {
+          txid:
+            "e0aadd861a06993e39af932bb0b9ad69e7b37ef5843a13c6724789e1c94f3513",
+          vout: 1,
+          scriptPubKey: "76a914a0f531f4ff810a415580c12e54a7072946bb927e88ac",
+          amount: 0.00008273,
+          satoshis: 8273,
+          confirmations: 0,
+          ts: 1526680569,
+          legacyAddress: "1Fg4r9iDrEkCcDmHTy2T79EusNfhyQpu7W",
+          cashAddress: "bitcoincash:qzs02v05l7qs5s24srqju498qu55dwuj0cx5ehjm2c"
         }
-      })
+      ]
+      const resolved: any = new Promise(r => r({ data: data }))
+      sandbox.stub(axios, "get").returns(resolved)
 
-      it(`should throw error on array size rate limit`, async () => {
-        try {
-          const addr = []
-          for (let i = 0; i < 25; i++)
-            addr.push("bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf")
+      bitbox.Address.unconfirmed(
+        "bitcoincash:qzs02v05l7qs5s24srqju498qu55dwuj0cx5ehjm2c"
+      )
+        .then((result: any) => {
+          assert.deepEqual(data, result)
+        })
+        .then(done, done)
+    })
+  })
+  /*
+  describe(`#utxo`, (): void => {
+    describe(`#details`, (): void => {
 
-          const result = await bitbox.Address.details(addr)
-
-          console.log(`result: ${util.inspect(result)}`)
-          assert.equal(true, false, "Unexpected result!")
-        } catch (err) {
-          assert.hasAnyKeys(err, ["error"])
-          assert.include(err.error, "Array too large")
-        }
-      })
       it(`should GET utxos for a single address`, async () => {
         const addr: string =
           "bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf"
@@ -1390,191 +1402,187 @@ describe("#Address", (): void => {
         }
       })
     })
+*/
+  describe(`#unconfirmed`, (): void => {
+    it(`should GET unconfirmed details on a single address`, async (): Promise<
+      any
+    > => {
+      const addr: string =
+        "bitcoincash:qz7teqlcltdhqjn2an8nspu7g2x6g3d3rcq8nk4nzs"
 
-    describe(`#unconfirmed`, (): void => {
-      it(`should GET unconfirmed details on a single address`, async (): Promise<
-        any
-      > => {
-        const addr: string =
-          "bitcoincash:qz7teqlcltdhqjn2an8nspu7g2x6g3d3rcq8nk4nzs"
+      const result:
+        | AddressUnconfirmedResult
+        | AddressUnconfirmedResult[] = await bitbox.Address.unconfirmed(addr)
 
-        const result:
-          | AddressUnconfirmedResult
-          | AddressUnconfirmedResult[] = await bitbox.Address.unconfirmed(addr)
+      assert.hasAllKeys(result, [
+        "utxos",
+        "legacyAddress",
+        "cashAddress",
+        "slpAddress",
+        "scriptPubKey"
+      ])
+      if (!Array.isArray(result)) assert.isArray(result.utxos)
+    })
 
-        assert.hasAllKeys(result, [
+    it(`should GET unconfirmed details on multiple addresses`, async (): Promise<
+      any
+    > => {
+      const addr = [
+        "bitcoincash:qz7teqlcltdhqjn2an8nspu7g2x6g3d3rcq8nk4nzs",
+        "bitcoincash:qqcp8fw06dmjd2gnfanpwytj7q93w408nv7usdqgsk"
+      ]
+
+      const result:
+        | AddressUnconfirmedResult
+        | AddressUnconfirmedResult[] = await bitbox.Address.unconfirmed(addr)
+
+      assert.isArray(result)
+      if (Array.isArray(result)) {
+        assert.hasAllKeys(result[0], [
           "utxos",
           "legacyAddress",
           "cashAddress",
           "slpAddress",
           "scriptPubKey"
         ])
-        if (!Array.isArray(result)) {
-          assert.isArray(result.utxos)
-        }
-      })
+        assert.isArray(result[0].utxos)
+      }
+    })
 
-      it(`should GET unconfirmed details on multiple addresses`, async (): Promise<
-        any
-      > => {
-        const addr = [
-          "bitcoincash:qz7teqlcltdhqjn2an8nspu7g2x6g3d3rcq8nk4nzs",
-          "bitcoincash:qqcp8fw06dmjd2gnfanpwytj7q93w408nv7usdqgsk"
-        ]
+    it(`should throw an error for improper input`, async () => {
+      try {
+        const addr: any = 12345
+
+        await bitbox.Address.unconfirmed(addr)
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        //console.log(`err: `, err)
+        assert.include(
+          err.message,
+          `Input address must be a string or array of strings`
+        )
+      }
+    })
+
+    it(`should throw error on array size rate limit`, async (): Promise<
+      any
+    > => {
+      try {
+        const addr: string[] = []
+        for (let i: number = 0; i < 25; i++)
+          addr.push("bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf")
 
         const result:
           | AddressUnconfirmedResult
           | AddressUnconfirmedResult[] = await bitbox.Address.unconfirmed(addr)
 
-        assert.isArray(result)
-        if (Array.isArray(result)) {
-          assert.hasAllKeys(result[0], [
-            "utxos",
-            "legacyAddress",
-            "cashAddress",
-            "slpAddress",
-            "scriptPubKey"
-          ])
-          assert.isArray(result[0].utxos)
-        }
-      })
+        console.log(`result: ${util.inspect(result)}`)
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        assert.hasAnyKeys(err, ["error"])
+        assert.include(err.error, "Array too large")
+      }
+    })
+  })
 
-      it(`should throw an error for improper input`, async () => {
-        try {
-          const addr: any = 12345
+  describe(`#transactions`, (): void => {
+    it(`should GET transactions for a single address`, async (): Promise<
+      any
+    > => {
+      const addr: string =
+        "bitcoincash:qz7teqlcltdhqjn2an8nspu7g2x6g3d3rcq8nk4nzs"
+      const result: any = await bitbox.Address.transactions(addr)
 
-          await bitbox.Address.unconfirmed(addr)
-          assert.equal(true, false, "Unexpected result!")
-        } catch (err) {
-          //console.log(`err: `, err)
-          assert.include(
-            err.message,
-            `Input address must be a string or array of strings`
-          )
-        }
-      })
-
-      it(`should throw error on array size rate limit`, async (): Promise<
-        any
-      > => {
-        try {
-          const addr: string[] = []
-          for (let i: number = 0; i < 25; i++)
-            addr.push("bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf")
-
-          const result:
-            | AddressUnconfirmedResult
-            | AddressUnconfirmedResult[] = await bitbox.Address.unconfirmed(
-            addr
-          )
-
-          console.log(`result: ${util.inspect(result)}`)
-          assert.equal(true, false, "Unexpected result!")
-        } catch (err) {
-          assert.hasAnyKeys(err, ["error"])
-          assert.include(err.error, "Array too large")
-        }
-      })
+      assert.hasAllKeys(result, [
+        "txs",
+        "pagesTotal",
+        "cashAddress",
+        "currentPage",
+        "legacyAddress"
+      ])
+      assert.isArray(result.txs)
+      assert.hasAnyKeys(result.txs[0], [
+        "txid",
+        "version",
+        "locktime",
+        "vin",
+        "vout",
+        "confirmations",
+        "time",
+        "blocktime",
+        "valueOut",
+        "size",
+        "valueIn",
+        "fees"
+      ])
     })
 
-    describe(`#transactions`, (): void => {
-      it(`should GET transactions for a single address`, async (): Promise<
-        any
-      > => {
-        const addr: string =
-          "bitcoincash:qz7teqlcltdhqjn2an8nspu7g2x6g3d3rcq8nk4nzs"
+    it(`should get transactions on multiple addresses`, async (): Promise<
+      any
+    > => {
+      const addr: string[] = [
+        "bitcoincash:qz7teqlcltdhqjn2an8nspu7g2x6g3d3rcq8nk4nzs",
+        "bitcoincash:qqcp8fw06dmjd2gnfanpwytj7q93w408nv7usdqgsk"
+      ]
+      const result: any = await bitbox.Address.transactions(addr)
+
+      assert.isArray(result)
+      assert.hasAllKeys(result[0], [
+        "txs",
+        "pagesTotal",
+        "cashAddress",
+        "currentPage",
+        "legacyAddress"
+      ])
+      assert.isArray(result[0].txs)
+      assert.hasAnyKeys(result[0].txs[0], [
+        "txid",
+        "version",
+        "locktime",
+        "vin",
+        "vout",
+        "confirmations",
+        "time",
+        "blocktime",
+        "valueOut",
+        "size",
+        "valueIn",
+        "fees"
+      ])
+    })
+
+    it(`should throw an error for improper input`, async (): Promise<any> => {
+      try {
+        const addr: any = 12345
+
+        await bitbox.Address.transactions(addr)
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        //console.log(`err: `, err)
+        assert.include(
+          err.message,
+          `Input address must be a string or array of strings`
+        )
+      }
+    })
+
+    it(`should throw error on array size rate limit`, async (): Promise<
+      any
+    > => {
+      try {
+        const addr: string[] = []
+        for (let i: number = 0; i < 25; i++)
+          addr.push("bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf")
+
         const result: any = await bitbox.Address.transactions(addr)
 
-        assert.hasAllKeys(result, [
-          "txs",
-          "pagesTotal",
-          "cashAddress",
-          "currentPage",
-          "legacyAddress"
-        ])
-        assert.isArray(result.txs)
-        assert.hasAnyKeys(result.txs[0], [
-          "txid",
-          "version",
-          "locktime",
-          "vin",
-          "vout",
-          "confirmations",
-          "time",
-          "blocktime",
-          "valueOut",
-          "size",
-          "valueIn",
-          "fees"
-        ])
-      })
-
-      it(`should get transactions on multiple addresses`, async (): Promise<
-        any
-      > => {
-        const addr: string[] = [
-          "bitcoincash:qz7teqlcltdhqjn2an8nspu7g2x6g3d3rcq8nk4nzs",
-          "bitcoincash:qqcp8fw06dmjd2gnfanpwytj7q93w408nv7usdqgsk"
-        ]
-        const result: any = await bitbox.Address.transactions(addr)
-
-        assert.isArray(result)
-        assert.hasAllKeys(result[0], [
-          "txs",
-          "pagesTotal",
-          "cashAddress",
-          "currentPage",
-          "legacyAddress"
-        ])
-        assert.isArray(result[0].txs)
-        assert.hasAnyKeys(result[0].txs[0], [
-          "txid",
-          "version",
-          "locktime",
-          "vin",
-          "vout",
-          "confirmations",
-          "time",
-          "blocktime",
-          "valueOut",
-          "size",
-          "valueIn",
-          "fees"
-        ])
-      })
-
-      it(`should throw an error for improper input`, async (): Promise<any> => {
-        try {
-          const addr: any = 12345
-
-          await bitbox.Address.transactions(addr)
-          assert.equal(true, false, "Unexpected result!")
-        } catch (err) {
-          //console.log(`err: `, err)
-          assert.include(
-            err.message,
-            `Input address must be a string or array of strings`
-          )
-        }
-      })
-
-      it(`should throw error on array size rate limit`, async (): Promise<
-        any
-      > => {
-        try {
-          const addr: string[] = []
-          for (let i: number = 0; i < 25; i++)
-            addr.push("bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf")
-
-          const result: any = await bitbox.Address.transactions(addr)
-
-          console.log(`result: ${util.inspect(result)}`)
-          assert.equal(true, false, "Unexpected result!")
-        } catch (err) {
-          assert.hasAnyKeys(err, ["error"])
-          assert.include(err.error, "Array too large")
-        }
-      })
+        console.log(`result: ${util.inspect(result)}`)
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        assert.hasAnyKeys(err, ["error"])
+        assert.include(err.error, "Array too large")
+      }
     })
   })
 })
+// })

--- a/test/unit/Address.ts
+++ b/test/unit/Address.ts
@@ -105,7 +105,6 @@ util.inspect.defaultOptions = {
 }
 
 describe("#Address", (): void => {
-  /*
   describe("#AddressConstructor", (): void => {
     it("should create instance of Address", (): void => {
       const address: Address = new Address()
@@ -1084,7 +1083,7 @@ describe("#Address", (): void => {
       }
     )
   })
-*/
+
   describe("#details", () => {
     let sandbox: any
     beforeEach(() => (sandbox = sinon.sandbox.create()))

--- a/test/unit/Address.ts
+++ b/test/unit/Address.ts
@@ -105,7 +105,7 @@ util.inspect.defaultOptions = {
 }
 
 describe("#Address", (): void => {
-/*
+  /*
   describe("#AddressConstructor", (): void => {
     it("should create instance of Address", (): void => {
       const address: Address = new Address()
@@ -1093,7 +1093,6 @@ describe("#Address", (): void => {
     it(`should GET address details for a single address`, async (): Promise<
       any
     > => {
-
       // Mock out data for unit test, to prevent live network call.
       const data: any = addressMock.details
       const resolved: any = new Promise(r => r({ data: data }))
@@ -1128,7 +1127,7 @@ describe("#Address", (): void => {
       if (!Array.isArray(result)) assert.isArray(result.transactions)
     })
 
-    it(`should GET address details for an array of addresses`, async (): Promise<
+    it(`should POST address details for an array of addresses`, async (): Promise<
       any
     > => {
       const addr: string[] = [
@@ -1136,9 +1135,15 @@ describe("#Address", (): void => {
         "bitcoincash:qpdh9s677ya8tnx7zdhfrn8qfyvy22wj4qa7nwqa5v"
       ]
 
+      // Mock out data for unit test, to prevent live network call.
+      const data: any = [addressMock.details, addressMock.details]
+      const resolved: any = new Promise(r => r({ data: data }))
+      sandbox.stub(axios, "post").returns(resolved)
+
       const result:
         | AddressDetailsResult
         | AddressDetailsResult[] = await bitbox.Address.details(addr)
+      //console.log(`result: ${JSON.stringify(result,null,2)}`)
 
       assert.isArray(result)
       if (Array.isArray(result)) {
@@ -1164,8 +1169,16 @@ describe("#Address", (): void => {
       }
     })
 
-    it(`should throw an error for improper input`, async () => {
+    it(`should pass error from server to user`, async () => {
       try {
+        // Mock out data for unit test, to prevent live network call.
+        sandbox
+          .stub(axios, "get")
+          .throws(
+            "error",
+            "Input address must be a string or array of strings."
+          )
+
         const addr: any = 12345
 
         await bitbox.Address.details(addr)
@@ -1177,53 +1190,6 @@ describe("#Address", (): void => {
           `Input address must be a string or array of strings`
         )
       }
-    })
-
-    it(`should throw error on array size rate limit`, async () => {
-      try {
-        const addr = []
-        for (let i = 0; i < 25; i++)
-          addr.push("bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf")
-
-        const result = await bitbox.Address.details(addr)
-
-        console.log(`result: ${util.inspect(result)}`)
-        assert.equal(true, false, "Unexpected result!")
-      } catch (err) {
-        assert.hasAnyKeys(err, ["error"])
-        assert.include(err.error, "Array too large")
-      }
-    })
-
-    it("should get details", done => {
-      const data: any = {
-        legacyAddress: "3CnzuFFbtgVyHNiDH8BknGo3PQ3dpdThgJ",
-        cashAddress: "bitcoincash:ppuukp49np467kyzxl0fkla34rmgcddhvc33ce2d6l",
-        balance: 300.0828874,
-        balanceSat: 30008288740,
-        totalReceived: 12945.45174649,
-        totalReceivedSat: 1294545174649,
-        totalSent: 12645.36885909,
-        totalSentSat: 1264536885909,
-        unconfirmedBalance: 0,
-        unconfirmedBalanceSat: 0,
-        unconfirmedTxApperances: 0,
-        txApperances: 1042,
-        transactions: [
-          "b29425a876f62e114508e67e66b5eb1ab0d320d7c9a57fb0ece086a36e2b7309"
-        ]
-      }
-
-      const resolved: any = new Promise(r => r({ data: data }))
-      sandbox.stub(axios, "get").returns(resolved)
-
-      bitbox.Address.details(
-        "bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf"
-      )
-        .then((result: any) => {
-          assert.deepEqual(data, result)
-        })
-        .then(done, done)
     })
   })
 

--- a/test/unit/Address.ts
+++ b/test/unit/Address.ts
@@ -1330,173 +1330,56 @@ describe("#Address", (): void => {
       }
     })
   })
-  /*
-  describe(`#utxo`, (): void => {
-    describe(`#details`, (): void => {
 
-      it(`should GET utxos for a single address`, async () => {
-        const addr: string =
-          "bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf"
-
-        const result:
-          | AddressUtxoResult
-          | AddressUtxoResult[] = await bitbox.Address.utxo(addr)
-
-        assert.hasAllKeys(result, [
-          "utxos",
-          "legacyAddress",
-          "cashAddress",
-          "slpAddress",
-          "scriptPubKey"
-        ])
-        if (!Array.isArray(result)) {
-          assert.isArray(result.utxos)
-          assert.hasAnyKeys(result.utxos[0], [
-            "txid",
-            "vout",
-            "amount",
-            "satoshis",
-            "height",
-            "confirmations"
-          ])
-        }
-      })
-
-      it(`should GET utxo details for an array of addresses`, async () => {
-        const addr: string[] = [
-          "bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf",
-          "bitcoincash:qpdh9s677ya8tnx7zdhfrn8qfyvy22wj4qa7nwqa5v"
-        ]
-
-        const result:
-          | AddressUtxoResult
-          | AddressUtxoResult[] = await bitbox.Address.utxo(addr)
-
-        assert.isArray(result)
-        if (Array.isArray(result)) {
-          assert.hasAllKeys(result[0], [
-            "utxos",
-            "legacyAddress",
-            "cashAddress",
-            "slpAddress",
-            "scriptPubKey"
-          ])
-          assert.isArray(result[0].utxos)
-          assert.hasAnyKeys(result[0].utxos[0], [
-            "txid",
-            "vout",
-            "amount",
-            "satoshis",
-            "height",
-            "confirmations"
-          ])
-        }
-      })
-
-      it(`should throw an error for improper input`, async () => {
-        try {
-          const addr: any = 12345
-
-          await bitbox.Address.utxo(addr)
-          assert.equal(true, false, "Unexpected result!")
-        } catch (err) {
-          //console.log(`err: `, err)
-          assert.include(
-            err.message,
-            `Input address must be a string or array of strings`
-          )
-        }
-      })
-
-      it(`should throw error on array size rate limit`, async (): Promise<
-        any
-      > => {
-        try {
-          const addr: string[] = []
-          for (let i: number = 0; i < 25; i++)
-            addr.push("bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf")
-
-          const result:
-            | AddressUtxoResult
-            | AddressUtxoResult[] = await bitbox.Address.utxo(addr)
-
-          console.log(`result: ${util.inspect(result)}`)
-          assert.equal(true, false, "Unexpected result!")
-        } catch (err) {
-          assert.hasAnyKeys(err, ["error"])
-          assert.include(err.error, "Array too large")
-        }
-      })
-    })
-*/
   describe(`#transactions`, (): void => {
+    let sandbox: any
+    beforeEach(() => (sandbox = sinon.sandbox.create()))
+    afterEach(() => sandbox.restore())
+
     it(`should GET transactions for a single address`, async (): Promise<
       any
     > => {
-      const addr: string =
-        "bitcoincash:qz7teqlcltdhqjn2an8nspu7g2x6g3d3rcq8nk4nzs"
-      const result: any = await bitbox.Address.transactions(addr)
+      // Mock out data for unit test, to prevent live network call.
+      const data: any = addressMock.transactions
+      const resolved: any = new Promise(r => r({ data: data }))
+      sandbox.stub(axios, "get").returns(resolved)
 
-      assert.hasAllKeys(result, [
-        "txs",
-        "pagesTotal",
-        "cashAddress",
-        "currentPage",
-        "legacyAddress"
-      ])
-      assert.isArray(result.txs)
-      assert.hasAnyKeys(result.txs[0], [
-        "txid",
-        "version",
-        "locktime",
-        "vin",
-        "vout",
-        "confirmations",
-        "time",
-        "blocktime",
-        "valueOut",
-        "size",
-        "valueIn",
-        "fees"
-      ])
+      const addr: string =
+        "bitcoincash:qrvk436u4r0ew2wj0rd9pnxhx4w90p2yfc29ta0d2n"
+
+      const result: any = await bitbox.Address.transactions(addr)
+      //console.log(`result: ${JSON.stringify(result,null,2)}`)
+
+      assert.deepEqual(data, result)
     })
 
     it(`should get transactions on multiple addresses`, async (): Promise<
       any
     > => {
+      // Mock out data for unit test, to prevent live network call.
+      const data: any = [addressMock.transactions, addressMock.transactions]
+      const resolved: any = new Promise(r => r({ data: data }))
+      sandbox.stub(axios, "post").returns(resolved)
+
       const addr: string[] = [
         "bitcoincash:qz7teqlcltdhqjn2an8nspu7g2x6g3d3rcq8nk4nzs",
         "bitcoincash:qqcp8fw06dmjd2gnfanpwytj7q93w408nv7usdqgsk"
       ]
       const result: any = await bitbox.Address.transactions(addr)
 
-      assert.isArray(result)
-      assert.hasAllKeys(result[0], [
-        "txs",
-        "pagesTotal",
-        "cashAddress",
-        "currentPage",
-        "legacyAddress"
-      ])
-      assert.isArray(result[0].txs)
-      assert.hasAnyKeys(result[0].txs[0], [
-        "txid",
-        "version",
-        "locktime",
-        "vin",
-        "vout",
-        "confirmations",
-        "time",
-        "blocktime",
-        "valueOut",
-        "size",
-        "valueIn",
-        "fees"
-      ])
+      assert.deepEqual(data, result)
     })
 
-    it(`should throw an error for improper input`, async (): Promise<any> => {
+    it(`should pass error from server to user`, async () => {
       try {
+        // Mock out data for unit test, to prevent live network call.
+        sandbox
+          .stub(axios, "get")
+          .throws(
+            "error",
+            "Input address must be a string or array of strings."
+          )
+
         const addr: any = 12345
 
         await bitbox.Address.transactions(addr)
@@ -1509,24 +1392,5 @@ describe("#Address", (): void => {
         )
       }
     })
-
-    it(`should throw error on array size rate limit`, async (): Promise<
-      any
-    > => {
-      try {
-        const addr: string[] = []
-        for (let i: number = 0; i < 25; i++)
-          addr.push("bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf")
-
-        const result: any = await bitbox.Address.transactions(addr)
-
-        console.log(`result: ${util.inspect(result)}`)
-        assert.equal(true, false, "Unexpected result!")
-      } catch (err) {
-        assert.hasAnyKeys(err, ["error"])
-        assert.include(err.error, "Array too large")
-      }
-    })
   })
 })
-// })

--- a/test/unit/fixtures/address-mock.js
+++ b/test/unit/fixtures/address-mock.js
@@ -22,5 +22,144 @@ module.exports = {
     currentPage: 0,
     pagesTotal: 1,
     slpAddress: "simpleledger:qrdka2205f4hyukutc2g0s6lykperc8nsuc8pkcp7h"
+  },
+
+  // An example of address with multiple utxos.
+  utxos1: {
+    utxos: [
+      {
+        txid:
+          "27ec8512c1a9ee9e9ae9b98eb60375f1d2bd60e2e76a1eff5a45afdbc517cf9c",
+        vout: 0,
+        amount: 0.001,
+        satoshis: 100000,
+        height: 560430,
+        confirmations: 25161
+      },
+      {
+        txid:
+          "6e1ae1bf7db6de799ec1c05ab2816ac65549bd80141567af088e6f291385b07d",
+        vout: 0,
+        amount: 0.0013,
+        satoshis: 130000,
+        height: 560039,
+        confirmations: 25552
+      }
+    ],
+    legacyAddress: "1M1FYu4zuVaxRPWLZG5CnP8qQrZaqu6c2L",
+    cashAddress: "bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf",
+    slpAddress: "simpleledger:qrdka2205f4hyukutc2g0s6lykperc8nsuc8pkcp7h",
+    scriptPubKey: "76a914db6ea94fa26b7272dc5e1487c35f258391e0f38788ac"
+  },
+
+  // An example of an address with no utxos.
+  utxos2: {
+    utxos: [],
+    legacyAddress: "19LXyLnux1tbTdHnMuYAgDZ81ZQDWEi12g",
+    cashAddress: "bitcoincash:qpdh9s677ya8tnx7zdhfrn8qfyvy22wj4qa7nwqa5v",
+    slpAddress: "simpleledger:qpdh9s677ya8tnx7zdhfrn8qfyvy22wj4q39c44a2j",
+    scriptPubKey: ""
+  },
+
+  // Example of an address with an unconfirmed UTXO
+  unconfirmed1: {
+    utxos: [
+      {
+        txid:
+          "3904ffe6f8fba4ceda5e887130f60fcb18bdc7dcee10392a57f89475c5c108f1",
+        vout: 0,
+        amount: 0.03608203,
+        satoshis: 3608203,
+        confirmations: 0,
+        ts: 1559670801
+      }
+    ],
+    legacyAddress: "1AyWs8U4HUnTLmxxFiGoJbsXauRsvBrcKW",
+    cashAddress: "bitcoincash:qpkkjkhe29mqhqmu3evtq3dsnruuzl3rku6usknlh5",
+    slpAddress: "simpleledger:qpkkjkhe29mqhqmu3evtq3dsnruuzl3rkuk8mdxlf2",
+    scriptPubKey: "76a9146d695af951760b837c8e58b045b098f9c17e23b788ac"
+  },
+
+  // Example of an address without any unconfirmed utxos.
+  unconfirmed2: {
+    utxos: [],
+    legacyAddress: "1M1FYu4zuVaxRPWLZG5CnP8qQrZaqu6c2L",
+    cashAddress: "bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf",
+    slpAddress: "simpleledger:qrdka2205f4hyukutc2g0s6lykperc8nsuc8pkcp7h",
+    scriptPubKey: "76a914db6ea94fa26b7272dc5e1487c35f258391e0f38788ac"
+  },
+
+  transactions: {
+    pagesTotal: 1,
+    txs: [
+      {
+        txid:
+          "ec7bc8349386e3e1939bbdc4f8092fdbdd6a380734e68486b558cd594c451d5b",
+        version: 2,
+        locktime: 0,
+        vin: [
+          {
+            txid:
+              "4f1fc57c33659628938db740449bf92fb75799e1d5750a4aeef80eb52d6df1e0",
+            vout: 0,
+            sequence: 4294967295,
+            n: 0,
+            scriptSig: {
+              hex:
+                "483045022100a3662a19ae384a1ceddea57765e425e61b04823e976d574da3911ac6b55d7f9b02200e571d985bce987675a2d58587a346fa40c39f4df13dc88548a92c52d5b24422412103f953f7630acc15bd3f5078c698f3af777286ae955b57e4857c158f75d87adb5f",
+              asm:
+                "3045022100a3662a19ae384a1ceddea57765e425e61b04823e976d574da3911ac6b55d7f9b02200e571d985bce987675a2d58587a346fa40c39f4df13dc88548a92c52d5b24422[ALL|FORKID] 03f953f7630acc15bd3f5078c698f3af777286ae955b57e4857c158f75d87adb5f"
+            },
+            addr: "17HPz8RQ4XM6mjre6aspvqyj1j648CZidM",
+            valueSat: 1111,
+            value: 0.00001111,
+            doubleSpentTxID: null
+          },
+          {
+            txid:
+              "126d62c299e7e14c66fe0b485d13082c23641f003690462046bc24ad2d1180c1",
+            vout: 0,
+            sequence: 4294967295,
+            n: 1,
+            scriptSig: {
+              hex:
+                "47304402203e3f923207111ff9bbd2fb5ab1a49a9145ad809ee0cad0e0ddaed64bfe38dc16022012ee288fb413bd500c63f8bb95e46b6b57d34762decd46b7188478a1c398eeda412103f953f7630acc15bd3f5078c698f3af777286ae955b57e4857c158f75d87adb5f",
+              asm:
+                "304402203e3f923207111ff9bbd2fb5ab1a49a9145ad809ee0cad0e0ddaed64bfe38dc16022012ee288fb413bd500c63f8bb95e46b6b57d34762decd46b7188478a1c398eeda[ALL|FORKID] 03f953f7630acc15bd3f5078c698f3af777286ae955b57e4857c158f75d87adb5f"
+            },
+            addr: "17HPz8RQ4XM6mjre6aspvqyj1j648CZidM",
+            valueSat: 1000,
+            value: 0.00001,
+            doubleSpentTxID: null
+          }
+        ],
+        vout: [
+          {
+            value: "0.00001736",
+            n: 0,
+            scriptPubKey: {
+              hex: "76a914d96ac75ca8df9729d278da50ccd7355c5785444e88ac",
+              asm:
+                "OP_DUP OP_HASH160 d96ac75ca8df9729d278da50ccd7355c5785444e OP_EQUALVERIFY OP_CHECKSIG",
+              addresses: ["1LpbYkEM5cryfhs58tH8c93p4SGzit7UrP"],
+              type: "pubkeyhash"
+            },
+            spentTxId: null,
+            spentIndex: null,
+            spentHeight: null
+          }
+        ],
+        blockheight: -1,
+        confirmations: 0,
+        time: 1559673337,
+        valueOut: 0.00001736,
+        size: 339,
+        valueIn: 0.00002111,
+        fees: 0.00000375
+      }
+    ],
+    legacyAddress: "1LpbYkEM5cryfhs58tH8c93p4SGzit7UrP",
+    cashAddress: "bitcoincash:qrvk436u4r0ew2wj0rd9pnxhx4w90p2yfc29ta0d2n",
+    currentPage: 0
   }
 }

--- a/test/unit/fixtures/address-mock.js
+++ b/test/unit/fixtures/address-mock.js
@@ -1,0 +1,26 @@
+/*
+  Mock data used for unit testing.
+*/
+
+module.exports = {
+  details: {
+    legacyAddress: "3CnzuFFbtgVyHNiDH8BknGo3PQ3dpdThgJ",
+    cashAddress: "bitcoincash:ppuukp49np467kyzxl0fkla34rmgcddhvc33ce2d6l",
+    balance: 300.0828874,
+    balanceSat: 30008288740,
+    totalReceived: 12945.45174649,
+    totalReceivedSat: 1294545174649,
+    totalSent: 12645.36885909,
+    totalSentSat: 1264536885909,
+    unconfirmedBalance: 0,
+    unconfirmedBalanceSat: 0,
+    unconfirmedTxApperances: 0,
+    txApperances: 1042,
+    transactions: [
+      "b29425a876f62e114508e67e66b5eb1ab0d320d7c9a57fb0ece086a36e2b7309"
+    ],
+    currentPage: 0,
+    pagesTotal: 1,
+    slpAddress: "simpleledger:qrdka2205f4hyukutc2g0s6lykperc8nsuc8pkcp7h"
+  }
+}


### PR DESCRIPTION
This adds unit tests for the `Address` class Insight API calls: Address.details, Address.utxo, Address.unconfirmed, and Address.transactions.