### PR TITLE
Bitsocket integration

### DIFF
--- a/lib/BITBOX.ts
+++ b/lib/BITBOX.ts
@@ -28,6 +28,8 @@ import { Util } from "./Util"
 // Defaults
 export const WS_URL = "wss://ws.bitcoin.com"
 export const TWS_URL = "wss://tws.bitcoin.com"
+export const BITSOCKET_URL = "https://bitsocket.bch.sx"
+export const TBITSOCKET_URL = "https://tbitsocket.bitcoin.com"
 export const REST_URL = "https://rest.bitcoin.com/v2/"
 export const TREST_URL = "https://trest.bitcoin.com/v2/"
 export const BITDB_URL = "https://bitdb.bitcoin.com/"

--- a/lib/Socket.ts
+++ b/lib/Socket.ts
@@ -4,20 +4,19 @@ import { SocketConfig } from "./interfaces/BITBOXInterfaces"
 const io: any = require("socket.io-client")
 export class Socket {
   socket: any
+  websocketURL: string
   bitsocketURL: string
   constructor(config: SocketConfig = {}) {
-    let websocketURL: string = ""
     if (config.wsURL) {
       // default to passed in wsURL
-      websocketURL = config.wsURL
+      this.websocketURL = config.wsURL
     } else if (config.restURL) {
       // 2nd option deprecated restURL
-      websocketURL = config.restURL
+      this.websocketURL = config.restURL
     } else {
       // fallback to WS_URL
-      websocketURL = WS_URL
+      this.websocketURL = WS_URL
     }
-    this.socket = io(websocketURL, { transports: ["websocket"] })
 
     if (config.bitsocketURL) {
       this.bitsocketURL = config.bitsocketURL
@@ -30,6 +29,7 @@ export class Socket {
 
   public listen(query: string, cb: Function): void {
     if (query === "blocks" || query === "transactions") {
+      this.socket = io(this.websocketURL, { transports: ["websocket"] })
       this.socket.emit(query)
 
       if (query === "blocks") this.socket.on("blocks", (msg: any) => cb(msg))
@@ -38,9 +38,8 @@ export class Socket {
     } else {
       let EventSource = require("eventsource")
       let b64 = Buffer.from(JSON.stringify(query)).toString("base64")
-      let socket = new EventSource(`${this.bitsocketURL}/s/${b64}`)
-
-      socket.onmessage = (msg: any) => {
+      this.socket = new EventSource(`${this.bitsocketURL}/s/${b64}`)
+      this.socket.onmessage = (msg: any) => {
         cb(msg.data)
       }
     }

--- a/lib/Socket.ts
+++ b/lib/Socket.ts
@@ -38,7 +38,7 @@ export class Socket {
     } else {
       let EventSource = require("eventsource")
       let b64 = Buffer.from(JSON.stringify(query)).toString("base64")
-      let socket = new EventSource(`${this.bitsocketURL}/s/` + b64)
+      let socket = new EventSource(`${this.bitsocketURL}/s/${b64}`)
 
       socket.onmessage = (msg: any) => {
         cb(msg.data)

--- a/lib/interfaces/BITBOXInterfaces.ts
+++ b/lib/interfaces/BITBOXInterfaces.ts
@@ -7,6 +7,7 @@ export interface IConfig {
 export interface SocketConfig {
   restURL?: string
   wsURL?: string
+  bitsocketURL?: string
   callback?: Function
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitbox-sdk",
-  "version": "8.6.0",
+  "version": "8.7.0",
   "description": "BITBOX SDK for Bitcoin Cash",
   "author": "Gabriel Cardona <gabriel@bitcoin.com>",
   "contributors": [
@@ -50,6 +50,7 @@
     "buffer": "^5.1.0",
     "cashaddrjs": "^0.2.9",
     "coininfo": "Bitcoin-com/coininfo",
+    "eventsource": "^1.0.7",
     "qrcode": "^1.2.0",
     "randombytes": "^2.0.6",
     "repl.history": "^0.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2384,6 +2384,13 @@ events@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/events/-/events-2.1.0.tgz#2a9a1e18e6106e0e812aa9ebd4a819b3c29c0ba5"
 
+eventsource@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-1.0.7.tgz#8fbc72c93fcd34088090bc0a4e64f4b5cee6d8d0"
+  integrity sha512-4Ln17+vVT0k8aWq+t/bF5arcS3EpT9gYtW66EPacdj/mAFevznsnyoHLPy2BA8gbIQeIHoPsvwmfBftfcG//BQ==
+  dependencies:
+    original "^1.0.0"
+
 evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz#7fcbdb198dc71959432efe13842684e0525acb02"
@@ -4825,6 +4832,13 @@ optionator@^0.8.2:
     type-check "~0.3.2"
     wordwrap "~1.0.0"
 
+original@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/original/-/original-1.0.2.tgz#e442a61cffe1c5fd20a65f3261c26663b303f25f"
+  integrity sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==
+  dependencies:
+    url-parse "^1.4.3"
+
 os-browserify@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.3.0.tgz#854373c7f5c2315914fc9bfc6bd8238fdda1ec27"
@@ -5351,6 +5365,11 @@ querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
 
+querystringify@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.1.tgz#60e5a5fd64a7f8bfa4d2ab2ed6fdf4c85bad154e"
+  integrity sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==
+
 quick-lru@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
@@ -5635,6 +5654,11 @@ require-uncached@^1.0.3:
   dependencies:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
+
+requires-port@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
+  integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
 resolve-from@^1.0.0:
   version "1.0.1"
@@ -6735,6 +6759,14 @@ url-parse-lax@^1.0.0:
   resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-1.0.0.tgz#7af8f303645e9bd79a272e7a14ac68bc0609da73"
   dependencies:
     prepend-http "^1.0.1"
+
+url-parse@^1.4.3:
+  version "1.4.7"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.7.tgz#a8a83535e8c00a316e403a5db4ac1b9b853ae278"
+  integrity sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==
+  dependencies:
+    querystringify "^2.1.1"
+    requires-port "^1.0.0"
 
 url-template@^2.0.8:
   version "2.0.8"


### PR DESCRIPTION
* Stream bitsocket data over fountainhead for now until we get our own bitsocket backend set up
* Add optional `bitsocketURL` to Socket config object
* Extend `listen` method's first `query` param to accept a bitsocket `query` object. Conditionally stream back full websocket data or bitsocket `query` to `callback`