### PR TITLE
[WIP] Util.sweep() for sweeping paper wallets

### DIFF
--- a/lib/Address.ts
+++ b/lib/Address.ts
@@ -253,6 +253,8 @@ export class Address {
     address: string | string[]
   ): Promise<AddressDetailsResult | AddressDetailsResult[]> {
     try {
+      console.log(`calling ${this.restURL}`)
+
       // Handle single address.
       if (typeof address === "string") {
         const response: AxiosResponse = await axios.get(

--- a/lib/Util.ts
+++ b/lib/Util.ts
@@ -49,4 +49,19 @@ export class Util {
       else throw error
     }
   }
+
+  // Sweep a private key in compressed WIF format and send funds to another address.
+  // Returns the amount of BCH swept from address. Or 0 if no funds were found.
+  // Passing in optional balanceOnly flag will return just the balance without
+  // actually moving the funds.
+  async sweep(wif: string, toAddr: string, balaneOnly: boolean) {
+    try {
+      console.log(`wif: ${wif}`)
+
+      return true
+    } catch (error) {
+      if (error.response && error.response.data) throw error.response.data
+      else throw error
+    }
+  }
 }

--- a/lib/Util.ts
+++ b/lib/Util.ts
@@ -1,6 +1,15 @@
 import axios, { AxiosRequestConfig, AxiosResponse } from "axios"
 import { REST_URL } from "./BITBOX"
 
+// Pull in additional libraries required to support the sweep function.
+import { Address } from "./Address"
+const addressLib = new Address(REST_URL)
+import { ECPair } from "./ECPair"
+const ecPair = new ECPair(addressLib)
+import { TransactionBuilder } from "./TransactionBuilder"
+import { BitcoinCash } from "./BitcoinCash"
+const bitcoinCash = new BitcoinCash(addressLib)
+
 export interface AddressDetails {
   isvalid: boolean
   address: string
@@ -50,15 +59,113 @@ export class Util {
     }
   }
 
-  // Sweep a private key in compressed WIF format and send funds to another address.
-  // Returns the amount of BCH swept from address. Or 0 if no funds were found.
+  // Sweep a private key in compressed WIF format and sends funds to another
+  // address.
   // Passing in optional balanceOnly flag will return just the balance without
   // actually moving the funds.
-  async sweep(wif: string, toAddr: string, balaneOnly: boolean) {
+  // Or 0 if no funds are found, otherwise:
+  // Returns an object containing the amount of BCH swept from address,
+  // and the txid of the generated transaction that swept the funds.
+  async sweep(wif: string, toAddr: string, balanceOnly: boolean) {
     try {
-      console.log(`wif: ${wif}`)
+      // Input validation
+      if (!wif || wif === "") {
+        throw new Error(
+          `wif private key must be included in Compressed WIF format.`
+        )
+      }
 
-      return true
+      // Input validation
+      if (!balanceOnly) {
+        if (!toAddr || toAddr === "") {
+          throw new Error(
+            `Address to receive swept funds must be included unless balanceOnly flag is true.`
+          )
+        }
+      }
+
+      // Generate a keypair from the WIF.
+      const keyPair = ecPair.fromWIF(wif)
+
+      // Generate the public address associated with the private key.
+      const fromAddr = ecPair.toCashAddress(keyPair)
+
+      // Check the BCH balance of that public address.
+      const details: any = await axios.get(
+        `${this.restURL}address/details/${fromAddr}`
+      )
+      const balance = details.data.balance
+
+      // If balance is zero, exit.
+      if(balance === 0) return balance
+
+      // If balanceOnly flag is passed in, exit.
+      if(balanceOnly) return balance
+
+      // Get UTXOs associated with public address.
+      const u: any = await axios.get(
+        `${this.restURL}address/utxo/${fromAddr}`
+      )
+      const utxos = u.data.utxos
+
+      // Prepare to generate a transaction to sweep funds.
+      const transactionBuilder = new TransactionBuilder()
+      let originalAmount = 0
+
+      // Add all UTXOs to the transaction inputs.
+      for (let i = 0; i < utxos.length; i++) {
+        const utxo = utxos[i]
+
+        originalAmount = originalAmount + utxo.satoshis
+
+        transactionBuilder.addInput(utxo.txid, utxo.vout)
+      }
+
+      if (originalAmount < 1)
+        throw new Error(`Original amount is zero. No BCH to send.`)
+
+      // get byte count to calculate fee. paying 1.1 sat/byte
+      const byteCount = bitcoinCash.getByteCount(
+        { P2PKH: utxos.length },
+        { P2PKH: 1 }
+      )
+      const fee = Math.ceil(1.1 * byteCount)
+
+      // amount to send to receiver. It's the original amount - 1 sat/byte for tx size
+      const sendAmount = originalAmount - fee
+
+      // add output w/ address and amount to send
+      transactionBuilder.addOutput(
+        addressLib.toLegacyAddress(toAddr),
+        sendAmount
+      )
+
+      // Loop through each input and sign it with the private key.
+      let redeemScript
+      for (var i = 0; i < utxos.length; i++) {
+        const utxo = utxos[i]
+
+        transactionBuilder.sign(
+          i,
+          keyPair,
+          redeemScript,
+          transactionBuilder.hashTypes.SIGHASH_ALL,
+          utxo.satoshis
+        )
+      }
+
+      // build tx
+      const tx = transactionBuilder.build()
+
+      // output rawhex
+      const hex = tx.toHex()
+
+      // Broadcast the transaction to the BCH network.
+      const response: any = await axios.get(
+        `${REST_URL}rawtransactions/sendRawTransaction/${hex}`
+      )
+
+      return response.data
     } catch (error) {
       if (error.response && error.response.data) throw error.response.data
       else throw error

--- a/test/integration/util.js
+++ b/test/integration/util.js
@@ -112,4 +112,19 @@ describe(`#util`, () => {
       }
     })
   })
+
+  describe("#sweep", () => {
+    it("should return balance only", async () => {
+      const wif = "L287yGQj4DB4fbUKSV7DMHsyGQs1qh2E3EYJ21P88mXNKaFvmNWk"
+      const result = await bitbox.Util.sweep(wif, "abc123", true)
+      console.log(`result: ${result}`)
+    })
+
+    it("should sweep funds", async () => {
+      const wif = "L287yGQj4DB4fbUKSV7DMHsyGQs1qh2E3EYJ21P88mXNKaFvmNWk"
+      const toAddr = "bitcoincash:qqjes5sxwneywmnzqndvs6p3l9rp55a2ug0e6e6s0a"
+      const result = await bitbox.Util.sweep(wif, toAddr)
+      console.log(`result: ${result}`)
+    })
+  })
 })

--- a/test/unit/Util.ts
+++ b/test/unit/Util.ts
@@ -123,11 +123,4 @@ describe("#Util", (): void => {
       }
     })
   })
-
-  describe('#sweep', () => {
-    it('should do something', async () => {
-      const result = await bitbox.Util.sweep('abc123', 'abc123', true)
-      console.log(`result: ${result}`)
-    })
-  })
 })

--- a/test/unit/Util.ts
+++ b/test/unit/Util.ts
@@ -123,4 +123,11 @@ describe("#Util", (): void => {
       }
     })
   })
+
+  describe('#sweep', () => {
+    it('should do something', async () => {
+      const result = await bitbox.Util.sweep('abc123', 'abc123', true)
+      console.log(`result: ${result}`)
+    })
+  })
 })


### PR DESCRIPTION
This PR is a work-in-progress (WIP) and should not be merged. It is created to solicit feedback.

## Scope
At @cgcardona's request, I added a sweep function to the BITBOX Utils library. This is a high-level function that can be used to 'sweep' a paper wallet and claim the funds on it.

## Food for Thought
I'm not totally satisfied with how this PR has shaped up. The functionality is in place, and I've added two prototype integration tests to exercise the function. I'll place call-outs in the code, but here are a few things I don't like about this implementation:

- I have to pull a whole bunch of the other libraries into the Util library in order to execute the sweep functionality. This makes me think that this sweep functionality is more appropriate for a different, higher-level library like [bch-cli-wallet](https://github.com/Bitcoin-com/bch-cli-wallet), or should be created as an example in the examples directory.

- Because the new sweep function makes a few calls to rest.bitcoin.com, it's going to be odd to create unit tests for it. End-to-end tests will be required to effectively test it. Unit and integration tests will provide minimal confidence on its expected behavior.

## To-Do
- Discuss the practicality of including this function in BITBOX.
- Add more comprehensive integration tests
- Add mocked unit tests.