### PR TITLE
Fixes to Script.encode function

### DIFF
--- a/lib/Address.ts
+++ b/lib/Address.ts
@@ -11,7 +11,7 @@ import { REST_URL } from "./BITBOX"
 
 // consts
 // TODO: port require statements to impprt
-const Bitcoin = require("bitcoincashjs-lib")
+const Bitcoin = require("@bitcoin-dot-com/bitcoincashjs2-lib")
 const cashaddr = require("cashaddrjs")
 const coininfo = require("coininfo")
 

--- a/lib/BitcoinCash.ts
+++ b/lib/BitcoinCash.ts
@@ -2,7 +2,7 @@
 import { Address } from "./Address"
 
 // consts
-const Bitcoin = require("bitcoincashjs-lib")
+const Bitcoin = require("@bitcoin-dot-com/bitcoincashjs2-lib")
 const sb = require("satoshi-bitcoin")
 const bitcoinMessage = require("bitcoinjs-message")
 const bs58 = require("bs58")

--- a/lib/Crypto.ts
+++ b/lib/Crypto.ts
@@ -1,5 +1,5 @@
 import randomBytes from "randombytes"
-const Bitcoin = require("bitcoincashjs-lib")
+const Bitcoin = require("@bitcoin-dot-com/bitcoincashjs2-lib")
 
 export class Crypto {
   public sha1(buffer: Buffer): Buffer {

--- a/lib/ECPair.ts
+++ b/lib/ECPair.ts
@@ -1,7 +1,7 @@
 import * as bcl from "bitcoincashjs-lib"
 import { Address } from "./Address"
 
-const Bitcoin = require("bitcoincashjs-lib")
+const Bitcoin = require("@bitcoin-dot-com/bitcoincashjs2-lib")
 const coininfo = require("coininfo")
 
 export class ECPair {

--- a/lib/HDNode.ts
+++ b/lib/HDNode.ts
@@ -3,7 +3,7 @@ import * as bcl from "bitcoincashjs-lib"
 import { Address } from "./Address"
 
 // consts
-const Bitcoin = require("bitcoincashjs-lib")
+const Bitcoin = require("@bitcoin-dot-com/bitcoincashjs2-lib")
 const coininfo = require("coininfo")
 const bip32utils = require("bip32-utils")
 

--- a/lib/Mnemonic.ts
+++ b/lib/Mnemonic.ts
@@ -6,7 +6,7 @@ import randomBytes from "randombytes"
 import * as wif from "wif"
 import { Address } from "./Address"
 // TODO: convert "bitcoincashjs-lib" require to import
-const Bitcoin = require("bitcoincashjs-lib")
+const Bitcoin = require("@bitcoin-dot-com/bitcoincashjs2-lib")
 
 export class Mnemonic {
   private _address: Address

--- a/lib/Script.ts
+++ b/lib/Script.ts
@@ -1,5 +1,5 @@
 // consts
-const Bitcoin = require("bitcoincashjs-lib")
+const Bitcoin = require("@bitcoin-dot-com/bitcoincashjs2-lib")
 const opcodes = require("bitcoincash-ops")
 
 export interface opcodes {

--- a/lib/Script.ts
+++ b/lib/Script.ts
@@ -262,6 +262,14 @@ export class Script {
     return Bitcoin.script.compile(arr)
   }
 
+  public encode2(scriptChunks: Array<number | Buffer>): Buffer {
+    const arr: Array<number | Buffer> = []
+    scriptChunks.forEach((chunk: number | Buffer) => {
+      arr.push(chunk)
+    })
+    return Bitcoin.script.compile2(arr)
+  }
+
   public decode(scriptBuffer: Buffer): Array<number | Buffer> {
     return Bitcoin.script.decompile(scriptBuffer)
   }

--- a/lib/TransactionBuilder.ts
+++ b/lib/TransactionBuilder.ts
@@ -5,7 +5,7 @@ import { Address } from "./Address"
 import { TREST_URL } from "./BITBOX"
 
 // consts
-const Bitcoin = require("bitcoincashjs-lib")
+const Bitcoin = require("@bitcoin-dot-com/bitcoincashjs2-lib")
 const coininfo = require("coininfo")
 const bip66 = require("bip66")
 const bip68 = require("bc-bip68")

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "url": "git+https://github.com/Bitcoin-com/bitbox-sdk.git"
   },
   "dependencies": {
+    "@bitcoin-dot-com/bitcoincashjs2-lib": "^4.1.0",
     "@types/bigi": "^1.4.2",
     "@types/bip39": "^2.4.2",
     "@types/randombytes": "^2.0.0",
@@ -48,7 +49,6 @@
     "bip39": "^2.5.0",
     "bip66": "^1.1.5",
     "bitcoincash-ops": "Bitcoin-com/bitcoincash-ops#2.0.0",
-    "bitcoincashjs-lib": "Bitcoin-com/bitcoincashjs-lib#v4.0.1",
     "bitcoinjs-message": "^2.0.0",
     "bs58": "^4.0.1",
     "cashaddrjs": "^0.2.9",

--- a/test/unit/Address.ts
+++ b/test/unit/Address.ts
@@ -16,7 +16,7 @@ const assert: Chai.AssertStatic = chai.assert
 
 // TODO: port from require to import syntax
 const fixtures = require("./fixtures/Address.json")
-const Bitcoin = require("bitcoincashjs-lib")
+const Bitcoin = require("@bitcoin-dot-com/bitcoincashjs2-lib")
 const sinon = require("sinon")
 const addressMock = require("./mocks/address-mock.js")
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -97,6 +97,27 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@bitcoin-dot-com/bitcoincashjs2-lib@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@bitcoin-dot-com/bitcoincashjs2-lib/-/bitcoincashjs2-lib-4.1.0.tgz#c01025d99f6472bb298fd801f9e7e7b1519f66d4"
+  integrity sha512-p36L4ZTVsLnFQuAdVVsDoIVYGglkyb1VWn8EEYo/kixUVdT7Mvf3gsJ0MG1wIP57SZLTj46hyhklTfT8fNbG0A==
+  dependencies:
+    bech32 "^1.1.2"
+    bigi "^1.4.0"
+    bip66 "^1.1.0"
+    bitcoincash-ops "github:Bitcoin-com/bitcoincash-ops#2.0.0"
+    bs58check "^2.0.0"
+    create-hash "^1.1.0"
+    create-hmac "^1.1.3"
+    ecurve "^1.0.0"
+    merkle-lib "^2.0.10"
+    pushdata-bitcoin "github:Bitcoin-com/pushdata-bitcoin#1.2.1"
+    randombytes "^2.0.1"
+    safe-buffer "^5.0.1"
+    typeforce "^1.11.3"
+    varuint-bitcoin "^1.0.4"
+    wif "^2.0.1"
+
 "@istanbuljs/nyc-config-typescript@^0.1.3":
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/@istanbuljs/nyc-config-typescript/-/nyc-config-typescript-0.1.3.tgz#944d15b3ebdb71f963a628daffaa25ade981bb86"
@@ -872,29 +893,9 @@ bip66@^1.1.0, bip66@^1.1.5:
   dependencies:
     safe-buffer "^5.0.1"
 
-bitcoincash-ops@Bitcoin-com/bitcoincash-ops#2.0.0:
+bitcoincash-ops@Bitcoin-com/bitcoincash-ops#2.0.0, "bitcoincash-ops@github:Bitcoin-com/bitcoincash-ops#2.0.0":
   version "2.0.0"
   resolved "https://codeload.github.com/Bitcoin-com/bitcoincash-ops/tar.gz/6ab82cc7326c67236f3b2d9d0457258ac2ef48e3"
-
-bitcoincashjs-lib@Bitcoin-com/bitcoincashjs-lib#v4.0.1:
-  version "4.0.1"
-  resolved "https://codeload.github.com/Bitcoin-com/bitcoincashjs-lib/tar.gz/28447b40a4ccd23913f7ade6589dc7214c99e60a"
-  dependencies:
-    bech32 "^1.1.2"
-    bigi "^1.4.0"
-    bip66 "^1.1.0"
-    bitcoincash-ops Bitcoin-com/bitcoincash-ops#2.0.0
-    bs58check "^2.0.0"
-    create-hash "^1.1.0"
-    create-hmac "^1.1.3"
-    ecurve "^1.0.0"
-    merkle-lib "^2.0.10"
-    pushdata-bitcoin Bitcoin-com/pushdata-bitcoin#1.2.1
-    randombytes "^2.0.1"
-    safe-buffer "^5.0.1"
-    typeforce "^1.11.3"
-    varuint-bitcoin "^1.0.4"
-    wif "^2.0.1"
 
 bitcoinjs-message@^2.0.0:
   version "2.1.0"
@@ -5341,7 +5342,7 @@ punycode@^2.1.0:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-pushdata-bitcoin@Bitcoin-com/pushdata-bitcoin#1.2.1:
+"pushdata-bitcoin@github:Bitcoin-com/pushdata-bitcoin#1.2.1":
   version "1.2.1"
   resolved "https://codeload.github.com/Bitcoin-com/pushdata-bitcoin/tar.gz/9b75eebe597853c6eeaec3e6c44b6d9c9cd7ee86"
   dependencies:


### PR DESCRIPTION
This PR replaces the older bitcoincashjs-lib with a new [bitcoincashjs2-lib](https://www.npmjs.com/package/@bitcoin-dot-com/bitcoincashjs2-lib) which has an alternative `encode2()` function, which does not mangle script codes. This fixes a slew of issues with trying to use BITBOX to naively compile SLP OP_RETURN outputs. It also fixes Issue #165.