### PR TITLE
Typescript fix for Randombytes

### DIFF
--- a/lib/Crypto.ts
+++ b/lib/Crypto.ts
@@ -1,4 +1,4 @@
-import randomBytes from "randombytes"
+import randomBytes from "./Randombytes"
 const Bitcoin = require("@bitcoin-dot-com/bitcoincashjs2-lib")
 
 export class Crypto {

--- a/lib/Mnemonic.ts
+++ b/lib/Mnemonic.ts
@@ -2,7 +2,7 @@ import * as BIP39 from "bip39"
 import * as bcl from "bitcoincashjs-lib"
 // import * as Bitcoin from "bitcoincashjs-lib"
 import { Buffer } from "buffer"
-import randomBytes from "randombytes"
+import randomBytes from "./Randombytes"
 import * as wif from "wif"
 import { Address } from "./Address"
 // TODO: convert "bitcoincashjs-lib" require to import

--- a/lib/Randombytes.ts
+++ b/lib/Randombytes.ts
@@ -1,0 +1,2 @@
+var randomBytes = require('randombytes');
+export default randomBytes;


### PR DESCRIPTION
Hi

In a new typescript project when using bitbox-sdk by `npm i bitbox-sdk`:

```ts
import { BITBOX } from 'bitbox-sdk'
let bitbox = new BITBOX();
bitbox.Mnemonic.generate()
```

When using tsc to compile the typescript it reports these errors:

```bash
C:\Users\rouan\Desktop\work\tempbitbox>tsc test.ts
node_modules/bitbox-sdk/lib/Crypto.ts:1:8 - error TS1259: Module '"C:/Users/rouan/Desktop/work/tempbitbox/node_modules/@types/randombytes/index"' can only be default-imported using the 'esModuleInterop' flag

1 import randomBytes from "randombytes"
         ~~~~~~~~~~~

  node_modules/@types/randombytes/index.d.ts:10:1
    10 export = randomBytes;
       ~~~~~~~~~~~~~~~~~~~~~
    This module is declared with using 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.

node_modules/bitbox-sdk/lib/Mnemonic.ts:5:8 - error TS1259: Module '"C:/Users/rouan/Desktop/work/tempbitbox/node_modules/@types/randombytes/index"' can only be default-imported using the 'esModuleInterop' flag

5 import randomBytes from "randombytes"
         ~~~~~~~~~~~

  node_modules/@types/randombytes/index.d.ts:10:1
    10 export = randomBytes;
       ~~~~~~~~~~~~~~~~~~~~~
    This module is declared with using 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.


Found 2 errors.
```

I found that this works around the issue.
