### PR TITLE
Fix issue 173 relating to zombie connections from Socket 

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@bitcoin-dot-com/bitcoincashjs2-lib": "^4.1.0",
     "@types/bigi": "^1.4.2",
     "@types/bip39": "^2.4.2",
+    "@types/eventsource": "^1.1.2",
     "@types/randombytes": "^2.0.0",
     "@types/socket.io": "^2.1.2",
     "@types/socket.io-client": "^1.4.32",

--- a/test/e2e/count-connections-issue-173/countConnectionsBitSocket.js
+++ b/test/e2e/count-connections-issue-173/countConnectionsBitSocket.js
@@ -1,0 +1,57 @@
+const BITBOX = require("../../../lib/BITBOX").BITBOX;
+const { exec } = require('child_process');
+
+const bitbox = new BITBOX();
+const socket = new bitbox.Socket();
+
+function countSockets(stage) {
+  return new Promise((resolve, reject) => {
+    // Call the lsof system command for outgoing internet connections.
+    exec(`lsof -i -n -P | grep ${process.pid}`, (err, stdout, stderr) => { 
+      // Print list of open connections allowing a visual count to be done.
+      console.log(`Outbound connections from this node process ${stage}:\n${stdout}`);
+      resolve();
+    });
+  });
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+(async () => {
+
+  await countSockets("before calling listen");
+
+  //First call to listen() which should create new connection.
+  socket.listen({"v": 3, "q": {"find": {}}},
+    (message) => {
+      console.log("Callback from first query invoked.");
+  });
+
+  //Second call to listen() which should share connection with first call.
+  socket.listen({"v": 3, "q": {"find": {}}},
+  (message) => {
+    console.log("Callback from first query invoked.");
+  });
+  
+  // listen doesn't return a promise so wait 100ms for connections to establish.
+  await sleep(100);
+  
+  await countSockets("after calling listen twice");
+
+  // now close the socket 
+  socket.close();
+
+  // callback from close() is short-circuited so give it 100ms to clean up.
+  await sleep(100);
+  
+  // check if any zombie connections remaining
+  await countSockets("after calling close (zombie connections)");
+
+  // exit process
+  process.exit();
+
+})();
+
+

--- a/test/e2e/count-connections-issue-173/countConnectionsBitSocket.js
+++ b/test/e2e/count-connections-issue-173/countConnectionsBitSocket.js
@@ -23,18 +23,23 @@ function sleep(ms) {
 
   await countSockets("before calling listen");
 
-  //First call to listen() which should create new connection.
+  // First call to listen() which should create new connection.
   socket.listen({"v": 3, "q": {"find": {}}},
     (message) => {
       console.log("Callback from first query invoked.");
   });
 
-  //Second call to listen() which should share connection with first call.
-  socket.listen({"v": 3, "q": {"find": {}}},
-  (message) => {
-    console.log("Callback from first query invoked.");
-  });
-  
+  // Second call to listen() which should share connection with first call.
+  // Use try catch in case this throws one of our new errors.
+  try {
+    socket.listen({"v": 3, "q": {"find": {}}},
+      (message) => {
+        console.log("Callback from first query invoked.");
+      });
+  } catch(error) {
+    console.log(`ERROR: ${error.message}`);
+  }
+    
   // listen doesn't return a promise so wait 100ms for connections to establish.
   await sleep(100);
   
@@ -52,6 +57,6 @@ function sleep(ms) {
   // exit process
   process.exit();
 
-})();
+})().catch((error)=> {console.log(`ERROR: ${error.message}`)});
 
 

--- a/test/e2e/count-connections-issue-173/countConnectionsMixedBitSocketFirst.js
+++ b/test/e2e/count-connections-issue-173/countConnectionsMixedBitSocketFirst.js
@@ -23,13 +23,15 @@ function sleep(ms) {
 
   await countSockets("before calling listen");
 
-  // First call to listen() which should create new connection.
-  socket.listen("transactions", (message) => {
-    console.log("Received a transaction.");
+  // First call to listen() which should create new BitSocket connection.
+  socket.listen({"v": 3, "q": {"find": {}}},
+    (message) => {
+      console.log("Callback from first query invoked.");
   });
-  
-  // Second call to listen() which should share connection with first call.
-  // Use try catch in case this throws one of our new errors.
+
+  // Second call to listen() which needs a socket.io connection and so can't
+  // share the exisiting connection. Use try catch in case this throws one of
+  // our new errors.
   try {
     socket.listen("blocks", (message) => {
       console.log("Received a block.");
@@ -37,7 +39,7 @@ function sleep(ms) {
   } catch(error) {
     console.log(`ERROR: ${error.message}`);
   }
-
+    
   // listen doesn't return a promise so wait 100ms for connections to establish.
   await sleep(100);
   
@@ -48,8 +50,8 @@ function sleep(ms) {
 
   // callback from close() is short-circuited so give it 100ms to clean up.
   await sleep(100);
-
-    // check if any zombie connections remaining
+  
+  // check if any zombie connections remaining
   await countSockets("after calling close (zombie connections)");
 
   // exit process

--- a/test/e2e/count-connections-issue-173/countConnectionsMixedSocketIOFirst.js
+++ b/test/e2e/count-connections-issue-173/countConnectionsMixedSocketIOFirst.js
@@ -27,17 +27,18 @@ function sleep(ms) {
   socket.listen("transactions", (message) => {
     console.log("Received a transaction.");
   });
-  
+
   // Second call to listen() which should share connection with first call.
   // Use try catch in case this throws one of our new errors.
   try {
-    socket.listen("blocks", (message) => {
-      console.log("Received a block.");
-    });
+    socket.listen({"v": 3, "q": {"find": {}}},
+      (message) => {
+        console.log("Callback from first query invoked.");
+      });
   } catch(error) {
     console.log(`ERROR: ${error.message}`);
   }
-
+    
   // listen doesn't return a promise so wait 100ms for connections to establish.
   await sleep(100);
   
@@ -48,8 +49,8 @@ function sleep(ms) {
 
   // callback from close() is short-circuited so give it 100ms to clean up.
   await sleep(100);
-
-    // check if any zombie connections remaining
+  
+  // check if any zombie connections remaining
   await countSockets("after calling close (zombie connections)");
 
   // exit process

--- a/test/e2e/count-connections-issue-173/countConnectionsSocketIO.js
+++ b/test/e2e/count-connections-issue-173/countConnectionsSocketIO.js
@@ -1,0 +1,55 @@
+const BITBOX = require("../../../lib/BITBOX").BITBOX;
+const { exec } = require('child_process');
+
+const bitbox = new BITBOX();
+const socket = new bitbox.Socket();
+
+function countSockets(stage) {
+  return new Promise((resolve, reject) => {
+    // Call the lsof system command for outgoing internet connections.
+    exec(`lsof -i -n -P | grep ${process.pid}`, (err, stdout, stderr) => { 
+      // Print list of open connections allowing a visual count to be done.
+      console.log(`Outbound connections from this node process ${stage}:\n${stdout}`);
+      resolve();
+    });
+  });
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+(async () => {
+
+  await countSockets("before calling listen");
+
+  //First call to listen() which should create new connection.
+  socket.listen("transactions", (message) => {
+    console.log("Received a transaction.");
+  });
+  
+  //Second call to listen() which should share connection with first call.
+  socket.listen("blocks", (message) => {
+    console.log("Received a block.");
+  });
+
+  // listen doesn't return a promise so wait 100ms for connections to establish.
+  await sleep(100);
+  
+  await countSockets("after calling listen twice");
+
+  // now close the socket 
+  socket.close();
+
+  // callback from close() is short-circuited so give it 100ms to clean up.
+  await sleep(100);
+  
+  // check if any zombie connections remaining
+  await countSockets("after calling close (zombie connections)");
+
+  // exit process
+  process.exit();
+
+})();
+
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -330,6 +330,11 @@
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
   integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
 
+"@types/eventsource@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@types/eventsource/-/eventsource-1.1.2.tgz#079ab4213e844e56f7384aec620e1163dab692b3"
+  integrity sha512-4AKWJ6tvEU4fk0770oAK4Z0lQUuSnc5ljHTcYZhQtdP7XMDKKvegGUC6xGD8+4+F+svZKAzlxbKnuGWfgMtgVA==
+
 "@types/glob@^7.1.1":
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.1.tgz#aa59a1c6e3fbc421e07ccd31a944c30eba521575"


### PR DESCRIPTION
Fixed this issue by adding a small enum-based state machine to track whether an instance is initialised and if so what connection type (socket.io vs BitSocket) it is being used for. 

Once an instance is of a certain type, queries of the other type or queries of same type that require a new connection will throw an error. This ensures that at most one connection exists at any time so that calling `close()` results in zero open connections.