### PR TITLE
Make send-bch example work on both testnet and mainnet 

### DIFF
--- a/examples/applications/wallet/send-bch/send-bch.js
+++ b/examples/applications/wallet/send-bch/send-bch.js
@@ -88,7 +88,7 @@ async function sendBch() {
     transactionBuilder.addOutput(SEND_ADDR, remainder)
 
     // Generate a change address from a Mnemonic of a private key.
-    const change = changeAddrFromMnemonic(SEND_MNEMONIC)
+    const change = changeAddrFromMnemonic(SEND_MNEMONIC,NETWORK)
 
     // Generate a keypair from the change address.
     const keyPair = bitbox.HDNode.toKeyPair(change)


### PR DESCRIPTION
Code is partially network-agnostic.
Current code always prints explorer for the testnet and always creates the change address for the mainnet.
Therefore, independently from the network, we do not obtain a coherent behaviour.

This commit allows the code to print the proper explorer link and generate a testnet change address when necessary