### PR TITLE
add regtest convertion to fromOutputScript

### DIFF
--- a/lib/Address.ts
+++ b/lib/Address.ts
@@ -237,15 +237,29 @@ export class Address {
     network: string = "mainnet"
   ): string {
     let netParam: any
-    if (network !== "bitcoincash" && network !== "mainnet")
-      netParam = Bitcoin.networks.testnet
-
-    const regtest: boolean = network === "bchreg"
+    let isRegtest: boolean
+    switch (network) {
+      case 'mainnet':
+        netParam = Bitcoin.networks.bitcoin
+        isRegtest = false
+        break
+      case 'testnet':
+        netParam = Bitcoin.networks.testnet
+        isRegtest = false
+        break
+      case 'regtest':
+        netParam = Bitcoin.networks.testnet
+        isRegtest = true
+        break
+      default:
+        netParam = Bitcoin.networks.bitcoin
+        isRegtest = false
+    }
 
     return this.toCashAddress(
       Bitcoin.address.fromOutputScript(scriptPubKey, netParam),
       true,
-      regtest
+      isRegtest
     )
   }
 

--- a/test/unit/Address.ts
+++ b/test/unit/Address.ts
@@ -1082,6 +1082,18 @@ describe("#Address", (): void => {
         })
       }
     )
+
+    fixtures.p2shRegTest.forEach(
+      (address: string): void => {
+        const p2shAddress: any = bitbox.Address.fromOutputScript(
+          scriptPubKey,
+          "regtest"
+        )
+        it(`generate regtest address from output script`, (): void => {
+          assert.equal(p2shAddress, address)
+        })
+      }
+    )
   })
 
   describe("#details", () => {

--- a/test/unit/fixtures/Address.json
+++ b/test/unit/fixtures/Address.json
@@ -225,6 +225,9 @@
   "p2shTestnet": [
     "bchtest:pz0qcslrqn7hr44hsszwl4lw5r6udkg6zqh2hmtpyr"
   ],
+  "p2shRegTest": [
+    "bchreg:pz0qcslrqn7hr44hsszwl4lw5r6udkg6zqdkp6gj89"
+  ],
   "mainnetXPriv": [
     {
       "xpriv": "xprvA2WwD9mk1Qd3rMjQ4ZRHvCWCj47jbXjY9Nf7npNRBmGUJngpRAvJzNpNgt7h2dDQ5huG7yFwYfz4PFJDPzkqfvBNPHnaio4yAbbUuv3EBnL",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "target": "es5",
     "downlevelIteration": true,
     "moduleResolution": "node",
-    "lib": ["es2017"],
+    "lib": ["es2017", "dom"],
     "sourceMap": true,
     "esModuleInterop": true
   },


### PR DESCRIPTION
currently fromOutputScript() do not support conversion from scriptPubKey to p2sh regtest address. So I add this capability with an additional test case.